### PR TITLE
Added missing addGraphQLSubscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ See [GitHunt-API](https://github.com/apollostack/GitHunt-API) and [GitHunt-React
   * `onSubscribe?: (message: SubscribeMessage, params: SubscriptionOptions, webSocketRequest: WebSocketRequest)` : optional method to create custom params that will be used when resolving this subscription
   * `keepAlive?: number` : optional interval in ms to send `SUBSCRIPTION_KEEPALIVE` messages to all clients
     
+### `addGraphQLSubscriptions(networkInterface, Client)`
+A Quick way to add the subscribe and unsubscribe functions to the [network interface](http://dev.apollodata.com/core/network.html#createNetworkInterface)
+
 ## Client-server messages
 Each message has a type, as well as associated fields depending on the message type.
 ### Client -> Server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscriptions-transport-ws",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A websocket transport for GraphQL subscriptions",
   "main": "dist/index.js",
   "repository": {
@@ -10,6 +10,7 @@
   "dependencies": {
     "backo2": "^1.0.2",
     "graphql-subscriptions": "^0.2.0",
+    "graphql-tag": "^1.2.3",
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",
     "websocket": "^1.0.23"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,19 @@
+import Client from './client';
+import { print } from 'graphql-tag/printer';
+
+// quick way to add the subscribe and unsubscribe functions to the network interface
+function addGraphQLSubscriptions(networkInterface: any, wsClient: Client): any {
+  return Object.assign(networkInterface, {
+    subscribe(request: any, handler: any): number {
+      return wsClient.subscribe({
+        query: print(request.query),
+        variables: request.variables,
+      }, handler);
+    },
+    unsubscribe(id: number): void {
+      wsClient.unsubscribe(id);
+    }
+  });
+}
+
+export { addGraphQLSubscriptions };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import Client from './client';
 import SubscriptionServer from './server';
-export { SubscriptionServer, Client };
+import { addGraphQLSubscriptions } from './helpers';
+export { addGraphQLSubscriptions, SubscriptionServer, Client };


### PR DESCRIPTION
Thought it may be time to add the missing `addGraphQLSubscriptions` helper function from the Subscriptions tutorial posted on [Medium](https://dev-blog.apollodata.com/graphql-subscriptions-in-apollo-client-9a2457f015fb#.7e9q6ir23) and linked here as an issue #38.

Code resides in a new `helper.ts`.