### PR TITLE
Create index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,5 @@
+export * from './client';
+export * from './server';
+export * from './helpers';
+export * from './messageTypes';
+export * from './protocols';


### PR DESCRIPTION
@angular/cli is not able to resolve the package.json 'browser' attribute. Maybe it would be better to have this simple index.ts file and change the package.json to point to it.

at the moment i have to use 

import { SubscriptionClient, addGraphQLSubscriptions } from 'subscriptions-transport-ws/dist/client';

to get import working in latest cli.

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
