### PR TITLE
Allow data and errors in payload of SUBSCRIPTION_DATA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+### 0.5.4
+- Allow data and errors in payload of SUBSCRIPTION_DATA [PR #84](https://github.com/apollographql/subscriptions-transport-ws/pull/84)
+
 ### 0.5.3
 - Fixed a bug with `browser` declaration on package.json ([Issue #79](https://github.com/apollographql/subscriptions-transport-ws/issues/79))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
 ### vNEXT
-
-### 0.5.4
 - Allow data and errors in payload of SUBSCRIPTION_DATA [PR #84](https://github.com/apollographql/subscriptions-transport-ws/pull/84)
 
 ### 0.5.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscriptions-transport-ws",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A websocket transport for GraphQL subscriptions",
   "main": "dist/server.js",
   "browser": "dist/client.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscriptions-transport-ws",
-  "version": "0.5.4",
+  "version": "0.5.3",
   "description": "A websocket transport for GraphQL subscriptions",
   "main": "dist/server.js",
   "browser": "dist/client.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -306,7 +306,8 @@ export class SubscriptionClient {
           if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
               this.subscriptions[subId].handler(null, parsedMessage.payload.data);
           } else {
-            this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), null);
+            const payloadData = parseMessage.payload.data || null
+            this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), payloadData);
           }
           break;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -306,7 +306,7 @@ export class SubscriptionClient {
           if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
               this.subscriptions[subId].handler(null, parsedMessage.payload.data);
           } else {
-            const payloadData = parseMessage.payload.data || null
+            const payloadData = parsedMessage.payload.data || null
             this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), payloadData);
           }
           break;

--- a/src/client.ts
+++ b/src/client.ts
@@ -303,14 +303,10 @@ export class SubscriptionClient {
 
           break;
         case SUBSCRIPTION_DATA:
-          if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
-              this.subscriptions[subId].handler(null, parsedMessage.payload.data);
-          } else {
-            const payloadData = parsedMessage.payload.data || null
-            this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), payloadData);
-          }
+          const payloadData = parsedMessage.payload.data || null;
+          const payloadErrors = parsedMessage.payload.errors ? this.formatErrors(parsedMessage.payload.errors) : null;
+          this.subscriptions[subId].handler(payloadErrors, payloadData);
           break;
-
         case KEEPALIVE:
           break;
 


### PR DESCRIPTION
Hi, at Graphcool, we have the use case, that sometimes we want to send `data` AND `errors` on the `payload` of `SUBSCRIPTION_DATA` at the same time.

This is especially needed for our permissions system, where it could be that the requesting client is only allowed to see some fields on a query. In that case we don't want to disable all other fields, so we send the allowed fields and an error that explains why some fields are null.

This PR just makes sure, that if there is the `errors` property, `data` is not just nulled, but is actually checked if there is data.