### PR TITLE
Send INIT before SUBSCRIPTION_START

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+### 0.5.4
+- Allow data and errors in payload of SUBSCRIPTION_DATA [PR #84](https://github.com/apollographql/subscriptions-transport-ws/pull/84)
+
 ### 0.5.3
 - Fixed a bug with `browser` declaration on package.json ([Issue #79](https://github.com/apollographql/subscriptions-transport-ws/issues/79))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscriptions-transport-ws",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A websocket transport for GraphQL subscriptions",
   "main": "dist/server.js",
   "browser": "dist/client.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -306,7 +306,8 @@ export class SubscriptionClient {
           if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
               this.subscriptions[subId].handler(null, parsedMessage.payload.data);
           } else {
-            this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), null);
+            const payloadData = parseMessage.payload.data || null
+            this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), payloadData);
           }
           break;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -306,7 +306,7 @@ export class SubscriptionClient {
           if (parsedMessage.payload.data && !parsedMessage.payload.errors) {
               this.subscriptions[subId].handler(null, parsedMessage.payload.data);
           } else {
-            const payloadData = parseMessage.payload.data || null
+            const payloadData = parsedMessage.payload.data || null
             this.subscriptions[subId].handler(this.formatErrors(parsedMessage.payload.errors), payloadData);
           }
           break;

--- a/src/client.ts
+++ b/src/client.ts
@@ -243,6 +243,9 @@ export class SubscriptionClient {
       this.eventEmitter.emit(isReconnect ? 'reconnect' : 'connect');
       this.reconnecting = false;
       this.backoff.reset();
+      // Send INIT message, no need to wait for connection to success (reduce roundtrips)
+      this.sendMessage({type: INIT, payload: this.connectionParams});
+
       Object.keys(this.reconnectSubscriptions).forEach((key) => {
         const { options, handler } = this.reconnectSubscriptions[key];
         this.subscribe(options, handler);
@@ -251,9 +254,6 @@ export class SubscriptionClient {
         this.client.send(JSON.stringify(message));
       });
       this.unsentMessagesQueue = [];
-
-      // Send INIT message, no need to wait for connection to success (reduce roundtrips)
-      this.sendMessage({type: INIT, payload: this.connectionParams});
     };
 
     this.client.onclose = () => {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -217,24 +217,24 @@ describe('Client', function () {
   });
 
   it('should send INIT message first, then the SUBSCRIPTION_START message', (done) => {
-    let initReceived = false
+    let initReceived = false;
 
+    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
     wsServer.on('connection', (connection: any) => {
       connection.on('message', (message: any) => {
         const parsedMessage = JSON.parse(message);
         // mock server
         if (parsedMessage.type === INIT) {
           connection.send(JSON.stringify({type: INIT_SUCCESS, payload: {}}));
-          initReceived = true
+          initReceived = true;
         }
         if (parsedMessage.type === SUBSCRIPTION_START) {
-          expect(initReceived).to.be.true
-          done()
+          expect(initReceived).to.be.true;
+          client.unsubscribeAll();
+          done();
         }
       });
     });
-
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
     client.subscribe(
       {
         query: `subscription useInfo {
@@ -242,7 +242,7 @@ describe('Client', function () {
             id
             name
           }
-        }`
+        }`,
       },
       (error, result) => {
         // do nothing


### PR DESCRIPTION
<img width="1081" alt="screen shot 2017-03-01 at 4 56 37 pm" src="https://cloud.githubusercontent.com/assets/1094804/23468075/1ed7058c-fea0-11e6-96bd-a116b6e3b1ab.png">
Currently, the `SUBSCRIPTION_START` is being sent before the `INIT` message.
In our case this results in `subscriptions-transport-ws` rejecting the `init_success` of the server.
This only happens in rare cases and I could barely reproduce this.
The environment that caused this problem looked like this:
 - Slow connection
 - Having 2 subscriptions in one application
 - Using the `react-apollo` client
I'm not sure if the apollo client is responsible for the weird early `subscription_end`, but this is already a starting point.

Unfortunately, the test I added breaks 3 other Server related tests. Seems some async/concurrency issue, but I couldn't find out what exactly is causing it.
If it is ok for you, I also just can remove this test, as all other tests then still are green.
This is based on PR #84, so you might first merge PR #84.