### PR TITLE
fix(NA): fixed infinity reconnects when server accepts connections bu…

### DIFF
--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -852,12 +852,59 @@ describe('Client', function () {
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
       timeout: 100,
       reconnect: true,
-      reconnectionAttempts: 1,
+      reconnectionAttempts: 2,
     });
+    const connectSpy = sinon.spy(subscriptionsClient, 'connect');
+
     setTimeout(() => {
-      expect(subscriptionsClient.status).to.be.equal(subscriptionsClient.client.CLOSED);
+      expect(connectSpy.callCount).to.be.equal(2);
       done();
     }, 500);
+  });
+
+  it('should stop trying to reconnect if not receives the ack from the server', function (done) {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+      reconnect: true,
+      reconnectionAttempts: 1,
+    });
+    const connectSpy = sinon.spy(subscriptionsClient, 'connect');
+    wsServer.on('connection', (connection: any) => {
+      connection.on('message', (message: any) => {
+        const parsedMessage = JSON.parse(message);
+        // mock server
+        if (parsedMessage.type === MessageTypes.GQL_CONNECTION_INIT) {
+          connection.close();
+        }
+      });
+    });
+
+    setTimeout(() => {
+      expect(connectSpy.callCount).to.be.equal(2);
+      done();
+    }, 1000);
+  });
+
+  it('should keep trying to reconnect if receives the ack from the server', function (done) {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+      reconnect: true,
+      reconnectionAttempts: 1,
+    });
+    const connectSpy = sinon.spy(subscriptionsClient, 'connect');
+    wsServer.on('connection', (connection: any) => {
+      connection.on('message', (message: any) => {
+        const parsedMessage = JSON.parse(message);
+        // mock server
+        if (parsedMessage.type === MessageTypes.GQL_CONNECTION_INIT) {
+          connection.send(JSON.stringify({ type: MessageTypes.GQL_CONNECTION_ACK, payload: {} }));
+          connection.close();
+        }
+      });
+    });
+
+    setTimeout(() => {
+      expect(connectSpy.callCount).to.be.greaterThan(2);
+      done();
+    }, 1000);
   });
 
   it('should take care of received keep alive', (done) => {


### PR DESCRIPTION
Guys ( @Urigo @DxCx @helfer @dotansimha @NeoPhi  )  this pull request is a fix for the following situation, otherwise will get an infinity reconnect loop:

1- client connects to the server normally with `reconnect = 3` and `reconnectionAttemps = 2` 
2- for some reason the server closes the connection
3- client tryReconnect as specified and servers accepts the basic connection, however don't send the `GQL_CONNECTION_ACK` and as it's in an internal error state closes the connection again
4- loop of point 3 infinity times. 

So in order to solve this the `backoff.reset()` and the `this.reconnecting = false` only occurs when `GQL_CONNECTION_ACK` is received.