### PR TITLE
feat(NA): force close without try reconnect

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -67,6 +67,7 @@ export class SubscriptionClient {
   private connectionCallback: any;
   private eventEmitter: EventEmitter;
   private lazy: boolean;
+  private forceClose: boolean;
   private wsImpl: any;
   private wasKeepAliveReceived: boolean;
   private checkConnectionTimeoutId: any;
@@ -100,6 +101,7 @@ export class SubscriptionClient {
     this.reconnecting = false;
     this.reconnectionAttempts = reconnectionAttempts;
     this.lazy = !!lazy;
+    this.forceClose = false;
     this.backoff = new Backoff({ jitter: 0.5 });
     this.eventEmitter = new EventEmitter();
     this.middlewares = [];
@@ -121,6 +123,7 @@ export class SubscriptionClient {
 
   public close() {
     if (this.client !== null) {
+      this.forceClose = true;
       this.client.close();
     }
   }
@@ -404,7 +407,12 @@ export class SubscriptionClient {
     this.client.onclose = () => {
       this.eventEmitter.emit('disconnect');
 
-      this.tryReconnect();
+      if (this.forceClose) {
+        this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_TERMINATE, null);
+        this.forceClose = false;
+      } else {
+        this.tryReconnect();
+      }
     };
 
     this.client.onerror = () => {


### PR DESCRIPTION
Guys ( @Urigo @DxCx @helfer @dotansimha @NeoPhi ) this pull request is a fix for the following situation:

1- Client connects to the server with `reconnect=true` to prevent for example temporary network failures.
2- Due to a necessary situation, for example a logout, the user of this package wants to close the client.
3- In this situation, even with `reconnect=true`, the `tryReconnect` method shouldn't be called.