### PR TITLE
refact(NA): onsubscribe middleware pr

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -20,7 +20,7 @@ export interface OperationOptions {
   query: string;
   variables?: Object;
   operationName?: string;
-  context?: any;
+  [key: string]: any;
 }
 
 export type FormatedError = Error & {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,0 @@
-import { OperationOptions } from './client';
-
-export interface MiddlewareInterface {
-  applyMiddleware(options: OperationOptions, next: Function): void;
-}

--- a/src/server.ts
+++ b/src/server.ts
@@ -312,7 +312,11 @@ export class SubscriptionServer {
               query: parsedMessage.payload.query,
               variables: parsedMessage.payload.variables,
               operationName: parsedMessage.payload.operationName,
-              context: Object.assign({}, isObject(initResult) ? initResult : {}, parsedMessage.payload.context),
+              context: Object.assign(
+                {},
+                isObject(initResult) ? initResult : {},
+                isObject(parsedMessage.payload.context) ? parsedMessage.payload.context : {},
+              ),
               formatResponse: <any>undefined,
               formatError: <any>undefined,
               callback: <any>undefined,

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,6 @@ export type ConnectionContext = {
 
 export interface OperationMessagePayload {
   [key: string]: any; // this will support for example any options sent in init like the auth token
-  context?: any;
   query?: string;
   variables?: { [key: string]: any };
   operationName?: string;
@@ -315,7 +314,6 @@ export class SubscriptionServer {
               context: Object.assign(
                 {},
                 isObject(initResult) ? initResult : {},
-                isObject(parsedMessage.payload.context) ? parsedMessage.payload.context : {},
               ),
               formatResponse: <any>undefined,
               formatError: <any>undefined,

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -302,37 +302,38 @@ describe('Client', function () {
     });
   });
 
-  it('should throw an exception when query is not provided', (done) => {
+  it('should throw an exception when query is not provided', () => {
     const client = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`);
 
-    client.subscribe({
-        query: undefined,
-        operationName: 'useInfo',
-        variables: {
-          id: 3,
+    expect(() => {
+      client.subscribe({
+          query: undefined,
+          operationName: 'useInfo',
+          variables: {
+            id: 3,
+          },
+        }, function (error: any, result: any) {
+          //do nothing
         },
-      }, function (error: any, result: any) {
-        expect(error).to.be.lengthOf(1);
-        done();
-      },
-    );
+      );
+    }).to.throw();
   });
 
-  it('should throw an exception when query is not valid', (done) => {
+  it('should throw an exception when query is not valid', () => {
     const client = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`);
 
-    client.subscribe({
-        query: <string>{},
-        operationName: 'useInfo',
-        variables: {
-          id: 3,
+    expect(() => {
+      client.subscribe({
+          query: <string>{},
+          operationName: 'useInfo',
+          variables: {
+            id: 3,
+          },
+        }, function (error: any, result: any) {
+          //do nothing
         },
-      }, function (error: any, result: any) {
-        //do nothing
-        expect(error).to.be.lengthOf(1);
-        done();
-      },
-    );
+      );
+    }).to.throw();
   });
 
   it('should throw an exception when handler is not provided', () => {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -302,38 +302,38 @@ describe('Client', function () {
     });
   });
 
-  it('should throw an exception when query is not provided', () => {
+  it('should throw an exception when query is not provided', (done) => {
     const client = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`);
 
-    expect(() => {
-      client.subscribe({
-          query: undefined,
-          operationName: 'useInfo',
-          variables: {
-            id: 3,
-          },
-        }, function (error: any, result: any) {
-          //do nothing
+    client.subscribe({
+        query: undefined,
+        operationName: 'useInfo',
+        variables: {
+          id: 3,
         },
-      );
-    }).to.throw();
+      }, function (error: any, result: any) {
+        expect(error).to.be.lengthOf(1);
+        expect(error[0].message).to.be.equal('Must provide a query.');
+        done();
+      },
+    );
   });
 
-  it('should throw an exception when query is not valid', () => {
+  it('should throw an exception when query is not valid', (done) => {
     const client = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`);
 
-    expect(() => {
-      client.subscribe({
-          query: <string>{},
-          operationName: 'useInfo',
-          variables: {
-            id: 3,
-          },
-        }, function (error: any, result: any) {
-          //do nothing
+    client.subscribe({
+        query: <string>{},
+        operationName: 'useInfo',
+        variables: {
+          id: 3,
         },
-      );
-    }).to.throw();
+      }, function (error: any, result: any) {
+        //do nothing
+        expect(error).to.be.lengthOf(1);
+        done();
+      },
+    );
   });
 
   it('should throw an exception when handler is not provided', () => {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -420,39 +420,46 @@ describe('Client', function () {
   });
 
   it('should override OperationOptions with middleware', function (done) {
-    const CTX = 'testContext';
-    const CTX2 = 'overrideContext';
     const client3 = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`);
-    client3.use([{
-      applyMiddleware(opts, next) {
-        // modify options for SubscriptionClient.subscribe here
-        setTimeout(() => {
-          opts.context = CTX2;
-          next();
-        }, 100);
+    let asyncFunc = (next: any) => {
+      setTimeout(() => {
+        next();
+      }, 100);
+    };
+    let spyApplyMiddlewareAsyncContents = sinon.spy(asyncFunc);
+    let middleware = {
+      applyMiddleware(opts: any, next: any) {
+        spyApplyMiddlewareAsyncContents(next);
       },
-    }]);
+    };
+    let spyApplyMiddlewareFunction = sinon.spy(middleware, 'applyMiddleware');
+    client3.use([ middleware ]);
 
     client3.subscribe({
-        query: `subscription context {
-          context
-        }`,
-        variables: {},
-        context: CTX,
+        query: `subscription useInfo($id: String) {
+            user(id: $id) {
+              id
+              name
+            }
+          }`,
+        operationName: 'useInfo',
+        variables: {
+          id: 3,
+        },
       }, (error: any, result: any) => {
         client3.unsubscribeAll();
         if (error) {
           assert(false, 'got error during subscription creation');
         }
         if (result) {
-          assert.property(result, 'context');
-          assert.equal(result.context, CTX2);
+          assert.equal(spyApplyMiddlewareFunction.called, true);
+          assert.equal(spyApplyMiddlewareAsyncContents.called, true);
         }
         done();
       },
     );
     setTimeout(() => {
-      subscriptionManager.publish('context', {});
+      subscriptionManager.publish('user', {});
     }, 200);
   });
 

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -853,7 +853,7 @@ describe('Client', function () {
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
       timeout: 100,
       reconnect: true,
-      reconnectionAttempts: 2,
+      reconnectionAttempts: 1,
     });
     const connectSpy = sinon.spy(subscriptionsClient, 'connect');
 


### PR DESCRIPTION
Guys ( @Urigo @DxCx @helfer @dotansimha @NeoPhi ) this PR is to refact somethings that were introduced by #78 

However I also want to raise up the discussion about the middleware thing that @DxCx also comments on #78.

Do we wanna be able to use a middleware and always send the context over the network in every request? Isn't this a severe security issue? Won't we be able to accomplish the exact same use case described on #78 sent the authtoken in the connectionParams with the new `lazy` option enabled?

In my opinion this should't be released until we got a really good conclusion. However I haven't removed that in this PR, I had only refact somethings and also fixing a bug. 