### PR TITLE
Don't skip opId === 0

### DIFF
--- a/src/adapters/subscription-manager.ts
+++ b/src/adapters/subscription-manager.ts
@@ -89,7 +89,7 @@ export const executeFromSubscriptionManager = (subscriptionManager: Subscription
 
         if (subIdPromise) {
           subIdPromise.then((opId: number) => {
-            if (opId) {
+            if (!isNaN(opId) && opId >= 0) {
               subscriptionManager.unsubscribe(opId);
             }
           });


### PR DESCRIPTION
I noticed that the first subscription is never unsubscribed.
Turns out that the first operation id is zero and that the `if (opId) {`
check is the culprit.

Fixes: #180

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
