### PR TITLE
chore(lodash): require specific lodash/assign module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Require specific lodash/assign module instead of entire package, so memory impact is reduced [PR #196](https://github.com/apollographql/subscriptions-transport-ws/pull/196)
 
 ### 0.7.3
 - Fix for first subscription is never unsubscribed [PR #179](https://github.com/apollographql/subscriptions-transport-ws/pull/179)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,5 @@
 import { SubscriptionClient } from './client';
-import assign from 'lodash/assign';
+import assign = require('lodash.assign');
 
 /**
  * @deprecated This method will become deprecated in the new package graphql-transport-ws.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,5 @@
 import { SubscriptionClient } from './client';
-import { assign } from 'lodash';
+import assign from 'lodash/assign';
 
 /**
  * @deprecated This method will become deprecated in the new package graphql-transport-ws.

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -228,7 +228,7 @@ new SubscriptionServer(onConnectErrorOptions, { server: httpServerWithOnConnectE
 const httpServerWithDelay = createServer(notFoundRequestListener);
 httpServerWithDelay.listen(DELAYED_TEST_PORT);
 new SubscriptionServer(Object.assign({}, options, {
-  onSubscribe: (msg: OperationMessagePayload | any, params: SubscriptionOptions) => {
+  onSubscribe: (msg: OperationMessagePayload | any, params: SubscriptionOptions): any => {
     return new Promise((resolve, reject) => {
       setTimeout(() => {
         resolve(Object.assign({}, params, { context: msg['context'] }));

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -2,6 +2,11 @@ interface Array<T> {
   indexOfField : (propertyName: string, value: any) => number;
 }
 
+declare module 'lodash.assign' {
+  import {assign} from 'lodash';
+  export = assign;
+}
+
 declare module 'lodash.isobject' {
   import {isObject} from 'lodash';
   export = isObject;


### PR DESCRIPTION
Importing from `lodash` loads the entire lib into memory unnecessarily.