### PR TITLE
fix(NA): Non forced close without connection terminate and also some connection's flow improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### vNEXT
+- Fix for non forced closes (now it wont send connection_terminate) [PR #197](https://github.com/apollographql/subscriptions-transport-ws/pull/197) 
+- A lot of connection's flow improvements (on connect, on disconnect and on reconnect) [PR #197](https://github.com/apollographql/subscriptions-transport-ws/pull/197)
 
 ### 0.7.3
 - Fix for first subscription is never unsubscribed [PR #179](https://github.com/apollographql/subscriptions-transport-ws/pull/179)

--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ ReactDOM.render(
 ### `Constructor(url, options, connectionCallback)`
 - `url: string` : url that the client will connect to, starts with `ws://` or `wss://`
 - `options?: Object` : optional, object to modify default client behavior
-  * `timeout?: number` : how long the client should wait in ms for a keep-alive message from the server (default 30000 ms), this parameter is ignored if the server does not send keep-alive messages.
+  * `timeout?: number` : how long the client should wait in ms for a keep-alive message from the server (default 10000 ms), this parameter is ignored if the server does not send keep-alive messages. This will also be used to calculate the max connection time per connect/reconnect
   * `lazy?: boolean` : use to set lazy mode - connects only when first subscription created, and delay the socket initialization
-  * `connectionParams?: Object | Function` : object that will be available as first argument of `onConnect` (in server side), if passed a function - it will call it and send the return value.
+  * `connectionParams?: Object | Function` : object that will be available as first argument of `onConnect` (in server side), if passed a function - it will call it and send the return value
   * `reconnect?: boolean` : automatic reconnect in case of connection error
   * `reconnectionAttempts?: number` : how much reconnect attempts
   * `connectionCallback?: (error) => {}` : optional, callback that called after the first init message, with the error (if there is one)

--- a/src/client.ts
+++ b/src/client.ts
@@ -466,7 +466,9 @@ export class SubscriptionClient {
       return;
     }
 
-    this.close(false, true);
+    if (!this.reconnecting) {
+      this.close(false, true);
+    }
   }
 
   private checkMaxConnectTimeout() {
@@ -486,9 +488,9 @@ export class SubscriptionClient {
     this.checkMaxConnectTimeout();
 
     this.client.onopen = () => {
+      this.clearMaxConnectTimeout();
       this.closedByUser = false;
       this.eventEmitter.emit(this.reconnecting ? 'reconnecting' : 'connecting');
-      this.clearMaxConnectTimeout();
 
       const payload: ConnectionParams = typeof this.connectionParams === 'function' ? this.connectionParams() : this.connectionParams;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -528,6 +528,7 @@ export class SubscriptionClient {
 
         if (this.checkConnectionTimeoutId) {
           clearTimeout(this.checkConnectionTimeoutId);
+          this.checkConnection();
         }
         this.checkConnectionTimeoutId = setTimeout(this.checkConnection.bind(this), this.wsTimeout);
         break;

--- a/src/client.ts
+++ b/src/client.ts
@@ -125,7 +125,11 @@ export class SubscriptionClient {
   public close(isForced = true) {
     if (this.client !== null) {
       this.forceClose = isForced;
-      this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_TERMINATE, null);
+
+      if (this.forceClose) {
+        this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_TERMINATE, null);
+      }
+
       this.client.close();
       this.client = null;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -461,6 +461,7 @@ export class SubscriptionClient {
     this.client.onerror = () => {
       // Capture and ignore errors to prevent unhandled exceptions, wait for
       // onclose to fire before attempting a reconnect.
+      this.close(false, true);
     };
 
     this.client.onmessage = ({ data }: {data: any}) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -131,7 +131,7 @@ export class SubscriptionClient {
         this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_TERMINATE, null);
       }
 
-      if (closedByUser) {
+      if (closedByUser && this.client.status < this.wsImpl.OPEN) {
         this.client.close();
       }
       this.client = null;
@@ -441,7 +441,7 @@ export class SubscriptionClient {
   }
 
   private checkConnection() {
-    this.wasKeepAliveReceived ? this.wasKeepAliveReceived = false : this.close(false);
+    this.wasKeepAliveReceived ? this.wasKeepAliveReceived = false : this.close(false, true);
   }
 
   private connect() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -131,6 +131,7 @@ export class SubscriptionClient {
       if (isForced) {
         if (this.checkConnectionIntervalId) {
           clearInterval(this.checkConnectionIntervalId);
+          this.checkConnectionIntervalId = null;
         }
 
         if (this.maxConnectTimeoutId) {
@@ -146,7 +147,7 @@ export class SubscriptionClient {
         this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_TERMINATE, null);
       }
 
-      if (closedByUser) {
+      if (this.client.status === this.wsImpl.OPEN) {
         this.client.close();
       }
       this.client = null;
@@ -456,7 +457,12 @@ export class SubscriptionClient {
   }
 
   private checkConnection() {
-    this.wasKeepAliveReceived ? this.wasKeepAliveReceived = false : this.close(false, true);
+    if (this.wasKeepAliveReceived) {
+      this.wasKeepAliveReceived = false;
+      return;
+    }
+
+    this.close(false, true);
   }
 
   private checkMaxConnectTimeout() {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,4 +1,4 @@
-const WS_TIMEOUT = 30000;
+const WS_TIMEOUT = 10000;
 
 export {
   WS_TIMEOUT,

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -314,7 +314,7 @@ describe('Client', function () {
   it('should emit disconnect event for client side when socket closed', (done) => {
     const client = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`, {
       connectionCallback: () => {
-        client.client.close(1001);
+        client.client.close();
       },
     });
 
@@ -970,7 +970,7 @@ describe('Client', function () {
     });
 
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
-      timeout: 10,
+      timeout: 100,
       reconnect: true,
       reconnectionAttempts: 1,
     });
@@ -979,7 +979,7 @@ describe('Client', function () {
     setTimeout(() => {
       expect(connectSpy.callCount).to.be.equal(2);
       done();
-    }, 1500);
+    }, 500);
   });
 
   it('should stop trying to reconnect if not receives the ack from the server', function (done) {
@@ -1174,7 +1174,7 @@ describe('Client', function () {
       let receivedDataParsed = JSON.parse(dataReceived.data);
       if (receivedDataParsed.type === MessageTypes.GQL_CONNECTION_ACK) {
         originalOnMessage(dataReceived);
-        subscriptionsClient.close(true);
+        subscriptionsClient.close();
       }
     };
 

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1138,7 +1138,7 @@ describe('Client', function () {
     }, 200);
   });
 
-  it.only('should force close the connection without tryReconnect', function (done) {
+  it('should force close the connection without tryReconnect', function (done) {
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
       reconnect: true,
       reconnectionAttempts: 1,
@@ -1176,7 +1176,7 @@ describe('Client', function () {
     }, 500);
   });
 
-  it.only('should close the connection without sent connection terminate and reconnect', function (done) {
+  it('should close the connection without sent connection terminate and reconnect', function (done) {
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
       reconnect: true,
       reconnectionAttempts: 1,

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -314,7 +314,7 @@ describe('Client', function () {
   it('should emit disconnect event for client side when socket closed', (done) => {
     const client = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`, {
       connectionCallback: () => {
-        client.client.close();
+        client.client.close(1001);
       },
     });
 
@@ -605,7 +605,7 @@ describe('Client', function () {
           connection.close();
 
           setTimeout(() => {
-            expect(client.client.readyState).to.equals(WebSocket.CLOSED);
+            expect(client.status).to.equals(WebSocket.CLOSED);
             done();
           }, 500);
         });
@@ -970,7 +970,7 @@ describe('Client', function () {
     });
 
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
-      timeout: 100,
+      timeout: 10,
       reconnect: true,
       reconnectionAttempts: 1,
     });
@@ -979,7 +979,7 @@ describe('Client', function () {
     setTimeout(() => {
       expect(connectSpy.callCount).to.be.equal(2);
       done();
-    }, 500);
+    }, 1500);
   });
 
   it('should stop trying to reconnect if not receives the ack from the server', function (done) {
@@ -1174,7 +1174,7 @@ describe('Client', function () {
       let receivedDataParsed = JSON.parse(dataReceived.data);
       if (receivedDataParsed.type === MessageTypes.GQL_CONNECTION_ACK) {
         originalOnMessage(dataReceived);
-        subscriptionsClient.close();
+        subscriptionsClient.close(true);
       }
     };
 
@@ -2013,7 +2013,7 @@ describe('Client<->Server Flow', () => {
 
         setTimeout(() => {
           // Disconnect the client
-          client.close();
+          client.close(false);
 
           // Subscribe to data, without manually reconnect before
           const opId = client.subscribe({


### PR DESCRIPTION
@Urigo @dotansimha @DxCx 

This PR solves the following issue: usually when a backend receives a `connection_terminate` will invalidate the previous credentials so we should only send connection_terminate in a `forceClose`.
