### PR TITLE
fix(NA): add a return after first post-install when it should install dev dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Return after first post-install when it should install dev dependencies [PR #218](https://github.com/apollographql/subscriptions-transport-ws/pull/218)
 
 ### 0.8.0
 - Expose opId `onOperationComplete` method [PR #211](https://github.com/apollographql/subscriptions-transport-ws/pull/211)

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -11,11 +11,12 @@ function exec(command) {
 }
 
 stat('dist', function(error, stat) {
+    if (process && process.env && process.env.npm_config_only !== 'dev') {
+            exec('npm install --only=dev');
+            return;
+    }
+
     if (error || !stat.isDirectory()) {
-    	if (process && process.env && process.env.npm_config_only !== 'dev') {
-        	exec('npm install --only=dev');
-    	}
-    	
         exec('npm run compile && npm run browser-compile && rimraf src');
     }
 });

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -11,11 +11,11 @@ function exec(command) {
 }
 
 stat('dist', function(error, stat) {
-    if (process && process.env && process.env.npm_config_only !== 'dev') {
-        exec('npm install --only=dev');
-    }
-
     if (error || !stat.isDirectory()) {
+    	if (process && process.env && process.env.npm_config_only !== 'dev') {
+        	exec('npm install --only=dev');
+    	}
+    	
         exec('npm run compile && npm run browser-compile && rimraf src');
     }
 });

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -12,8 +12,8 @@ function exec(command) {
 
 stat('dist', function(error, stat) {
     if (process && process.env && process.env.npm_config_only !== 'dev') {
-            exec('npm install --only=dev');
-            return;
+        exec('npm install --only=dev');
+        return;
     }
 
     if (error || !stat.isDirectory()) {


### PR DESCRIPTION
@Urigo @dotansimha @DxCx this is only a small fix so when installing from a branch it doesn't repeat the compile job for 2 times. 