### PR TITLE
fix(NA): on install from branch install dev dependencies only if dist folder isnt found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 - Return after first post-install when it should install dev dependencies [PR #218](https://github.com/apollographql/subscriptions-transport-ws/pull/218)
+- On installing from branch install dev dependencies only if dist folder isnt found [PR #219](https://github.com/apollographql/subscriptions-transport-ws/pull/219)
 
 ### 0.8.0
 - Expose opId `onOperationComplete` method [PR #211](https://github.com/apollographql/subscriptions-transport-ws/pull/211)

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -11,12 +11,12 @@ function exec(command) {
 }
 
 stat('dist', function(error, stat) {
-    if (process && process.env && process.env.npm_config_only !== 'dev') {
-        exec('npm install --only=dev');
-        return;
-    }
-
     if (error || !stat.isDirectory()) {
+        if (process && process.env && process.env.npm_config_only !== 'dev') {
+            exec('npm install --only=dev');
+            return;
+        }
+
         exec('npm run compile && npm run browser-compile && rimraf src');
     }
 });


### PR DESCRIPTION
@Urigo  This is a small fix to only install dev dependencies if it is an install from branch situation.