### PR TITLE
fix(NA): send first keep alive message right after connection ack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Send first keep alive message right after the ack [PR #223](https://github.com/apollographql/subscriptions-transport-ws/pull/223)
 - Return after first post-install when it should install dev dependencies [PR #218](https://github.com/apollographql/subscriptions-transport-ws/pull/218)
 - On installing from branch install dev dependencies only if dist folder isnt found [PR #219](https://github.com/apollographql/subscriptions-transport-ws/pull/219)
 


### PR DESCRIPTION
@Urigo @dotansimha @DxCx this small commits fixs a bug that I found in sequence of helping a user in the issue #220 . We should send the first KA message right after the connection ack in the server side. 