### PR TITLE
Adds request interface to match apollo 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Add request interface as a preperation for Apollo 2.0 [PR #242](https://github.com/apollographql/subscriptions-transport-ws/pull/242)
 - Add Validation step to server [PR #241](https://github.com/apollographql/subscriptions-transport-ws/pull/241)
 - Call operation handler before delete the operation on operation complete [PR #239](https://github.com/apollographql/subscriptions-transport-ws/pull/239)
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash.assign": "^4.2.0",
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",
+    "symbol-observable": "^1.0.4",
     "ws": "^3.0.0"
   },
   "scripts": {


### PR DESCRIPTION
This PR adds support for Apollo's ObservableNetworkInterface.
once Apollo version 2.0 is out, we should add integration with apollo-link,
however now it will be easier as the main function is already implemented.

Closes #201 

TODO:

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
