### PR TITLE
fix(NA): gracefully unsubscribe to all pending operations before a requested close by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Gracefully unsubscribe to all pending operations before a requested close by the user  [PR #245](https://github.com/apollographql/subscriptions-transport-ws/pull/245)
 
 ### 0.8.2
 - Add request interface as a preparation for Apollo 2.0 [PR #242](https://github.com/apollographql/subscriptions-transport-ws/pull/242)

--- a/src/client.ts
+++ b/src/client.ts
@@ -148,6 +148,7 @@ export class SubscriptionClient {
         this.clearCheckConnectionInterval();
         this.clearMaxConnectTimeout();
         this.clearTryReconnectTimeout();
+        this.unsubscribeAll();
         this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_TERMINATE, null);
       }
 
@@ -519,7 +520,7 @@ export class SubscriptionClient {
       default:
         if (!this.reconnecting) {
           throw new Error('A message was not sent because socket is not connected, is closing or ' +
-            'is already closed. Message was: ${JSON.parse(serializedMessage)}.');
+            'is already closed. Message was: ' + JSON.stringify(message));
         }
     }
   }


### PR DESCRIPTION
@DxCx @Urigo @dotansimha this is a small fix for the close method.
