### PR TITLE
Observer callbacks should be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Bugfix: Observer callbacks should be optional [PR #256](https://github.com/apollographql/subscriptions-transport-ws/pull/256)
 
 ### 0.8.2
 - Add request interface as a preparation for Apollo 2.0 [PR #242](https://github.com/apollographql/subscriptions-transport-ws/pull/242)

--- a/src/client.ts
+++ b/src/client.ts
@@ -185,11 +185,17 @@ export class SubscriptionClient {
           operationName: request.operationName,
         }, function (error: Error[], result: any) {
           if ( error === null && result === null ) {
-            observer.complete();
+            if ( observer.complete ) {
+              observer.complete();
+            }
           } else if (error) {
-            observer.error(error[0]);
+            if ( observer.error ) {
+              observer.error(error[0]);
+            }
           } else {
-            observer.next(result);
+            if ( observer.next ) {
+              observer.next(result);
+            }
           }
         });
 


### PR DESCRIPTION
Small bugfix to make sure undefined callbacks won't be used.