### PR TITLE
chore: add close method to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Add `close` method to server [PR #257](https://github.com/apollographql/subscriptions-transport-ws/pull/257)
 
 ### 0.8.2
 - Add request interface as a preparation for Apollo 2.0 [PR #242](https://github.com/apollographql/subscriptions-transport-ws/pull/242)


### PR DESCRIPTION
1. Exposes `server` for `noServer` configuration when user needs to emit `connection`.
2. add `close` method to disconnect all clients & remove connection hooks. (Closes #255)

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
