### PR TITLE
docs(README): Fix example for subscribe and subscribeToMore methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- docs(README): Fix example for subscribe and subscribeToMore [PR #273](https://github.com/apollographql/subscriptions-transport-ws/pull/273)
 - Add support for GraphQL 0.11.0 [PR #261](https://github.com/apollographql/subscriptions-transport-ws/pull/261)
 - **BREAKING CHANGE**: Remove support for Subscription Manager [PR #261](https://github.com/apollographql/subscriptions-transport-ws/pull/261)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ const apolloClient = new ApolloClient({
 });
 ```
 
-Now, when you want to use subscriptions in client side, use your `ApolloClient` instance, with `subscribe` or `query` `subscribeToMore`:
+Now, when you want to use subscriptions in client side, use your `ApolloClient` instance, with [`subscribe`](http://dev.apollodata.com/core/apollo-client-api.html#ObservableQuery\.subscribe) or `query` [`subscribeToMore`](http://dev.apollodata.com/react/subscriptions.html#subscribe-to-more):
 
 ```js
 apolloClient.subscribe({

--- a/README.md
+++ b/README.md
@@ -133,20 +133,40 @@ const apolloClient = new ApolloClient({
 });
 ```
 
-Now, when you want to use subscriptions in client side, use your `ApolloClient` instance, with `subscribe` or `subscribeToMore` (according to your apollo-client usage):
+Now, when you want to use subscriptions in client side, use your `ApolloClient` instance, with `subscribe` or `query` `subscribeToMore`:
 
 ```js
-apolloClient.subscribeToMore({
-    query: gql`
-        subscription onNewItem {
-            newItemCreated {
-                id
-            }
-        }`,
-    variables: {},
-    updateQuery: (prev, {subscriptionData}) => {
-        // Modify your store and return new state with the new arrived data
-    }
+apolloClient.subscribe({
+  query: gql`
+    subscription onNewItem {
+        newItemCreated {
+            id
+        }
+    }`,
+  variables: {}
+}).subscribe({
+  next (data) {
+    // Notify your application with the new arrived data
+  }
+});
+```
+
+```js
+apolloClient.query({
+  query: ITEM_LIST_QUERY,
+  variables: {}
+}).subscribeToMore({
+  document: gql`
+    subscription onNewItem {
+        newItemCreated {
+            id
+        }
+    }`,
+  variables: {},
+  updateQuery: (prev, { subscriptionData, variables }) => {
+    // Perform updates on previousResult with subscriptionData
+    return updatedResult;
+  }
 });
 ```
 


### PR DESCRIPTION
Add 2 examples for both `subscribe` and `subscribeToMore`.

`subscribeToMore` is not a function on apolloClient but working on a query result. Fix #265
`subscribe` need a subscriber for a full working example.

Both example were test with hybrid and Full WebSocket Transport.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
