### PR TITLE
docs(KEEP_ALIVE): updated protocol documentation to explain the correct workflow between connection_init, connection_ack and connection_keep_alive messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- docs(KEEP_ALIVE): Updated protocol docs to explain the correct server implementation of `GQL_CONNECTION_INIT`, `GQL_CONNECTION_ACK` and `GQL_CONNECTION_KEEP_ALIVE` [PR #279](https://github.com/apollographql/subscriptions-transport-ws/pull/279)
 
 ### 0.9.0
 - docs(README): Fix example for subscribe and subscribeToMore [PR #273](https://github.com/apollographql/subscriptions-transport-ws/pull/273)

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -21,7 +21,7 @@ export interface OperationMessage {
 #### GQL_CONNECTION_INIT
 Client sends this message after plain websocket connection to start the communication with the server
 
-The server will response only with `GQL_CONNECTION_ACK` or `GQL_CONNECTION_ERROR` to this message.
+The server will response only with `GQL_CONNECTION_ACK` + `GQL_CONNECTION_KEEP_ALIVE` (if used) or `GQL_CONNECTION_ERROR` to this message.
 
 - `payload: Object` : optional parameters that the client specifies in `connectionParams`
 
@@ -74,9 +74,9 @@ Server sends this message to indicate that a GraphQL operation is done, and no m
 - `id: string` : operation ID of the operation that completed
 
 #### GQL_CONNECTION_KEEP_ALIVE
-Server message sent periodically to keep the client connection alive.
+Server message that should be sent right after each `GQL_CONNECTION_ACK` processed and then periodically to keep the client connection alive.
 
-The client starts to considerer the keep alive message only upon the first received keep alive message from the server.
+The client starts to consider the keep alive message only upon the first received keep alive message from the server.
 
 ### Messages Flow
 
@@ -86,10 +86,10 @@ This is a demonstration of client-server communication, in order to get a better
 
 The phase initializes the connection between the client and server, and usually will also build the server-side `context` for the execution.
 
-- Client connected immediatly, or stops and wait if using lazy mode (until first operation execution)
+- Client connected immediately, or stops and wait if using lazy mode (until first operation execution)
 - Client sends `GQL_CONNECTION_INIT` message to the server.
-- Server calls `onConnect` callback with the init arguments, waits for init to finish and returns it's return value with `GQL_CONNECTION_ACK`, or `GQL_CONNECTION_ERROR` in case of `false` or thrown exception from `onConnect` callback.
-- Client gets `GQL_CONNECTION_ACK` and waits for the client's app to create subscriptions.
+- Server calls `onConnect` callback with the init arguments, waits for init to finish and returns it's return value with `GQL_CONNECTION_ACK` + `GQL_CONNECTION_KEEP_ALIVE` (if used), or `GQL_CONNECTION_ERROR` in case of `false` or thrown exception from `onConnect` callback.
+- Client gets `GQL_CONNECTION_ACK` + `GQL_CONNECTION_KEEP_ALIVE` (if used) and waits for the client's app to create subscriptions.
 
 #### Connected Phase
 


### PR DESCRIPTION
This PR fixes a missing information on the protocol documentation that should explains the correct message flow between the messages: connection_init, connection_ack and connection_keep_alive messages.

The one suggested by the current documentation is:

`--> connection_init` - 0s
`<-- connection_ack` - 0s
`<-- ka` .                     - 10s

Which is wrong.

The one suggested by this docs update, and the one that should be used is:

`--> connection_init` - 0s
`<-- connection_ack` - 0s
`<-- ka` .                     - 0s
`<-- ka` .                     - 10s

You can found more information about how I found this, in a discussion between myself and some graphcool guys here graphcool/graphcool#309.