### PR TITLE
Made language a little clearer.

### DIFF
--- a/src/message-types.ts
+++ b/src/message-types.ts
@@ -3,7 +3,7 @@ export default class MessageTypes {
   public static GQL_CONNECTION_ACK = 'connection_ack'; // Server -> Client
   public static GQL_CONNECTION_ERROR = 'connection_error'; // Server -> Client
 
-  // NOTE: This one here don't follow the standard due to connection optimization
+  // NOTE: These message types do not follow the standard due to connection optimizations
   public static GQL_CONNECTION_KEEP_ALIVE = 'ka'; // Server -> Client
   public static GQL_CONNECTION_TERMINATE = 'connection_terminate'; // Client -> Server
   public static GQL_START = 'start'; // Client -> Server
@@ -12,7 +12,7 @@ export default class MessageTypes {
   public static GQL_COMPLETE = 'complete'; // Server -> Client
   public static GQL_STOP = 'stop'; // Client -> Server
 
-  // NOTE: Those message types are deprecated and will be removed soon.
+  // NOTE: These message types are deprecated and will be removed soon.
   /**
    * @deprecated
    */

--- a/src/message-types.ts
+++ b/src/message-types.ts
@@ -3,8 +3,9 @@ export default class MessageTypes {
   public static GQL_CONNECTION_ACK = 'connection_ack'; // Server -> Client
   public static GQL_CONNECTION_ERROR = 'connection_error'; // Server -> Client
 
-  // NOTE: These message types do not follow the standard due to connection optimizations
+  // NOTE: The keep alive message type does not follow the standard due to connection optimizations
   public static GQL_CONNECTION_KEEP_ALIVE = 'ka'; // Server -> Client
+  
   public static GQL_CONNECTION_TERMINATE = 'connection_terminate'; // Client -> Server
   public static GQL_START = 'start'; // Client -> Server
   public static GQL_DATA = 'data'; // Server -> Client
@@ -12,7 +13,7 @@ export default class MessageTypes {
   public static GQL_COMPLETE = 'complete'; // Server -> Client
   public static GQL_STOP = 'stop'; // Client -> Server
 
-  // NOTE: These message types are deprecated and will be removed soon.
+  // NOTE: The following message types are deprecated and will be removed soon.
   /**
    * @deprecated
    */


### PR DESCRIPTION
"This" in the top comment is a little unclear as it's unclear whether that comment refers to just the next message type or the entire block.
"Those" on the bottom comment is a little unclear as "those" is past tense, it could refer to the preceding message types.

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
