### PR TITLE
add wasDataReceived

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -84,6 +84,7 @@ export class SubscriptionClient {
   private lazy: boolean;
   private closedByUser: boolean;
   private wsImpl: any;
+  private wasDataReceived :boolean;
   private wasKeepAliveReceived: boolean;
   private tryReconnectTimeoutId: any;
   private checkConnectionIntervalId: any;
@@ -471,11 +472,12 @@ export class SubscriptionClient {
   }
 
   private checkConnection() {
-    if (this.wasKeepAliveReceived) {
+    if (this.wasKeepAliveReceived || this.wasDataReceived) {
       this.wasKeepAliveReceived = false;
+      this.wasDataReceived = false;
       return;
     }
-
+  
     if (!this.reconnecting) {
       this.close(false, true);
     }
@@ -579,6 +581,7 @@ export class SubscriptionClient {
         const parsedPayload = !parsedMessage.payload.errors ?
           parsedMessage.payload : {...parsedMessage.payload, errors: this.formatErrors(parsedMessage.payload.errors)};
         this.operations[opId].handler(null, parsedPayload);
+        this.wasDataReceived = true;
         break;
 
       case MessageTypes.GQL_CONNECTION_KEEP_ALIVE:


### PR DESCRIPTION
In some case ( Graph Cool ) , it will send KA message every 10s , unless send data.
If the server is keeping send data message , it will trigger reconnect and make some message drop during reconnect.

If we can receive message , it means we are connecting . so 'wasKeepAliveReceived' should also be true.
I am going to add a new variable 'wasDataReceived' means receive data, and checking in checkconnect
It prevent reconnect when the connection still avaliable.