### PR TITLE
improved keep alive handling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 dist/test
+src/

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coverage": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- --full-trace ./dist/test/tests.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info",
     "browser-compile": "webpack --config \"./unpkg-webpack.config.js\"",
-    "prepublishOnly": "npm run compile && npm run browser-compile && rimraf src",
+    "prepublishOnly": "npm run compile && npm run browser-compile",
     "postinstall": "node scripts/post-install.js"
   },
   "peerDependencies": {

--- a/src/message-types.ts
+++ b/src/message-types.ts
@@ -46,6 +46,10 @@ export default class MessageTypes {
    * @deprecated
    */
   public static INIT_FAIL = 'init_fail';
+  /**
+   * @deprecated
+   */
+  public static KEEP_ALIVE = 'keepalive';
 
   constructor() {
     throw new Error('Static Class');

--- a/src/server.ts
+++ b/src/server.ts
@@ -145,17 +145,6 @@ export class SubscriptionServer {
       connectionContext.socket = socket;
       connectionContext.operations = {};
 
-      // Regular keep alive messages if keepAlive is set
-      if (this.keepAlive) {
-        const keepAliveTimer = setInterval(() => {
-          if (socket.readyState === WebSocket.OPEN) {
-            this.sendMessage(connectionContext, undefined, MessageTypes.GQL_CONNECTION_KEEP_ALIVE, undefined);
-          } else {
-            clearInterval(keepAliveTimer);
-          }
-        }, this.keepAlive);
-      }
-
       const connectionClosedHandler = (error: any) => {
         if (error) {
           this.sendError(
@@ -282,12 +271,15 @@ export class SubscriptionServer {
             );
 
             if (this.keepAlive) {
-              this.sendMessage(
-                connectionContext,
-                undefined,
-                MessageTypes.GQL_CONNECTION_KEEP_ALIVE,
-                undefined,
-              );
+              this.sendKeepAlive(connectionContext);
+              // Regular keep alive messages if keepAlive is set
+              const keepAliveTimer = setInterval(() => {
+                if (connectionContext.socket.readyState === WebSocket.OPEN) {
+                  this.sendKeepAlive(connectionContext);
+                } else {
+                  clearInterval(keepAliveTimer);
+                }
+              }, this.keepAlive);
             }
           }).catch((error: Error) => {
             this.sendError(
@@ -459,6 +451,14 @@ export class SubscriptionServer {
           this.sendError(connectionContext, opId, { message: 'Invalid message type!' });
       }
     };
+  }
+
+  private sendKeepAlive(connectionContext: ConnectionContext): void {
+    if (connectionContext.isLegacy) {
+      this.sendMessage(connectionContext, undefined, MessageTypes.KEEP_ALIVE, undefined);
+    } else {
+      this.sendMessage(connectionContext, undefined, MessageTypes.GQL_CONNECTION_KEEP_ALIVE, undefined);
+    }
   }
 
   private sendMessage(connectionContext: ConnectionContext, opId: string, type: string, payload: any): void {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1941,11 +1941,38 @@ describe('Server', function () {
       const parsedMessage = JSON.parse(message.data);
       if (parsedMessage.type === MessageTypes.GQL_CONNECTION_KEEP_ALIVE) {
         yieldCount += 1;
-        if (yieldCount > 1) {
+        if (yieldCount > 2) {
           client.close();
           done();
         }
       }
+    };
+    client.onopen = () => {
+      client.send(JSON.stringify({
+        id: 1,
+        type: MessageTypes.GQL_CONNECTION_INIT,
+      }));
+    };
+  });
+
+  it('sends legacy keep alive signal in the socket', function (done) {
+    let client = new WebSocket(`ws://localhost:${KEEP_ALIVE_TEST_PORT}/`, GRAPHQL_SUBSCRIPTIONS);
+    let yieldCount = 0;
+    client.onmessage = (message: any) => {
+      const parsedMessage = JSON.parse(message.data);
+      if (parsedMessage.type === MessageTypes.KEEP_ALIVE) {
+        yieldCount += 1;
+        if (yieldCount > 2) {
+          client.close();
+          done();
+        }
+      }
+    };
+    client.onopen = () => {
+      client.send(JSON.stringify({
+        id: 1,
+        type: MessageTypes.INIT,
+      }));
     };
   });
 });


### PR DESCRIPTION
While updating our backend server to the latest version of this package we noticed backwards compatible issues with clients that were still on v1 of the protocol. These two fixes ensure that old clients get the deprecated keep alive message and that those messages are not sent until the client successfully establishes a connection (otherwise a keep alive of the wrong message type maybe sent).

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
