### PR TITLE
Fix: returning promises created in handlers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -411,6 +411,7 @@ export class SubscriptionServer {
               this.unsubscribe(connectionContext, opId);
               return;
             });
+            return promisedParams;
           }).catch((error) => {
             // Handle initPromise rejected
             this.sendError(connectionContext, opId, { message: error.message });


### PR DESCRIPTION
See: http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it

This pull request resolved the warnings I received when using subscription-transport-ws with Bluebird installed as the global Promise object (`global.Promise = require('bluebird')`):

```
(node:17404) Warning: a promise was created in a handler at [REDACTED]/node_modules/subscriptions-transport-ws/src/server.ts:316:42 but was not
returned from it, see http://goo.gl/rRqMUw
    at Function.Promise.cast (/[REDACTED]/node_modules/bluebird/js/release/promise.js:196:13)
    at /[REDACTED]/node_modules/subscriptions-transport-ws/src/server.ts:316:42                                                                     at runCallback (timers.js:773:18)
    at tryOnImmediate (timers.js:734:5)
    at processImmediate [as _immediateCallback] (timers.js:711:5)
```