### PR TITLE
fix: context cloning for classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- fix shallow cloning on contexts which are classes
 
 ### 0.9.5
 - docs(setup): Fix dead link to subscriptions-to-schema

--- a/src/server.ts
+++ b/src/server.ts
@@ -305,10 +305,7 @@ export class SubscriptionServer {
               query: parsedMessage.payload.query,
               variables: parsedMessage.payload.variables,
               operationName: parsedMessage.payload.operationName,
-              context: Object.assign(
-                {},
-                isObject(initResult) ? initResult : {},
-              ),
+              context: isObject(initResult) ? Object.assign(Object.create(Object.getPrototypeOf(initResult)), initResult) : {},
               formatResponse: <any>undefined,
               formatError: <any>undefined,
               callback: <any>undefined,


### PR DESCRIPTION
this fixes a bug that is similar to a bug found in [apollo-server](https://github.com/apollographql/apollo-server/pull/679)
Would be great to see this merged so we can use subscriptions

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
