### PR TITLE
Emit event when an websocket error occurs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- added `error` event to handle connection errors and debug network troubles [PR #341](https://github.com/apollographql/subscriptions-transport-ws/pull/341).
 
 ### v0.9.7
 - change default timeout from 10s to 30s [PR #368](https://github.com/apollographql/subscriptions-transport-ws/pull/368)

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ ReactDOM.render(
 #### `unsubscribeAll() => void` - unsubscribes from all active subscriptions.
 
 #### `on(eventName, callback, thisContext) => Function`
-- `eventName: string`: the name of the event, available events are: `connecting`, `connected`, `reconnecting`, `reconnected` and `disconnected`
+- `eventName: string`: the name of the event, available events are: `connecting`, `connected`, `reconnecting`, `reconnected`, `disconnected` and `error`
 - `callback: Function`: function to be called when websocket connects and initialized.
 - `thisContext: any`: `this` context to use when calling the callback function.
 - => Returns an `off` method to cancel the event subscription.
@@ -282,6 +282,11 @@ ReactDOM.render(
 
 #### `onDisconnected(callback, thisContext) => Function` - shorthand for `.on('disconnected', ...)`
 - `callback: Function`: function to be called when websocket disconnected.
+- `thisContext: any`: `this` context to use when calling the callback function.
+- => Returns an `off` method to cancel the event subscription.
+
+#### `onError(callback, thisContext) => Function` - shorthand for `.on('error', ...)`
+- `callback: Function`: function to be called when an error occurs.
 - `thisContext: any`: `this` context to use when calling the callback function.
 - => Returns an `off` method to cancel the event subscription.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -234,6 +234,10 @@ export class SubscriptionClient {
     return this.on('reconnecting', callback, context);
   }
 
+  public onError(callback: ListenerFn, context?: any): Function {
+    return this.on('error', callback, context);
+  }
+
   public unsubscribeAll() {
     Object.keys(this.operations).forEach( subId => {
       this.unsubscribe(subId);
@@ -514,9 +518,10 @@ export class SubscriptionClient {
       }
     };
 
-    this.client.onerror = () => {
+    this.client.onerror = (err: Error) => {
       // Capture and ignore errors to prevent unhandled exceptions, wait for
       // onclose to fire before attempting a reconnect.
+      this.eventEmitter.emit('error', err);
     };
 
     this.client.onmessage = ({ data }: {data: any}) => {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -948,6 +948,26 @@ describe('Client', function () {
     }, 1000);
   });
 
+  it('should emit event when an websocket error occurs', function (done) {
+    const client = new SubscriptionClient(`ws://localhost:${ERROR_TEST_PORT}/`);
+
+    client.request({
+      query: `subscription useInfo{
+        invalid
+      }`,
+      variables: {},
+    }).subscribe({
+      next: () => {
+        assert(false);
+      },
+    });
+
+    client.onError((err: Error) => {
+      expect(err.message).to.be.equal(`connect ECONNREFUSED 127.0.0.1:${ERROR_TEST_PORT}`);
+      done();
+    });
+  });
+
   it('should stop trying to reconnect to the server', function (done) {
     wsServer.on('connection', (connection: WebSocket) => {
       connection.close();


### PR DESCRIPTION
**Use case:**
Writing simple (load)testing tools. At that moment there is no simple way to determinate connection errors. Also useful to debug network troubles.

**Could this be a plugin?**
No, we can't subscribe to ws error event directly.

**Is there a workaround?**
Save connection state(to check that connection closed by server) and catch `disconnected` event. But we don't have any error details.

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
