### PR TITLE
add optional payload to ACK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   [@jedwards1211](https://github.com/jedwards1211) in [#675](https://github.com/apollographql/subscriptions-transport-ws/pull/675)
 - Accept extra WebSocket client arguments.  <br/>
   [@GingerBear](https://github.com/GingerBear) in [#561](https://github.com/apollographql/subscriptions-transport-ws/pull/561)
+- Support server-defined payload in GQL_CONNECTION_ACK message.  <br/>
+  [@mattkrick](https://github.com/mattkrick) in [#347](https://github.com/apollographql/subscriptions-transport-ws/pull/347)
 
 ## v0.9.17
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -51,6 +51,7 @@ It server also respond with this message in case of a parsing errors of the mess
 
 #### GQL_CONNECTION_ACK
 The server may responses with this message to the `GQL_CONNECTION_INIT` from client, indicates the server accepted the connection.
+May optionally include a payload.
 
 
 #### GQL_DATA

--- a/README.md
+++ b/README.md
@@ -263,12 +263,12 @@ ReactDOM.render(
 - => Returns an `off` method to cancel the event subscription.
 
 #### `onConnected(callback, thisContext) => Function` - shorthand for `.on('connected', ...)`
-- `callback: Function`: function to be called when websocket connects and initialized, after ACK message returned from the server
+- `callback: Function(payload)`: function to be called when websocket connects and initialized, after ACK message returned from the server. Includes payload from server, if any.
 - `thisContext: any`: `this` context to use when calling the callback function.
 - => Returns an `off` method to cancel the event subscription.
 
 #### `onReconnected(callback, thisContext) => Function` - shorthand for `.on('reconnected', ...)`
-- `callback: Function`: function to be called when websocket reconnects and initialized, after ACK message returned from the server
+- `callback: Function(payload)`: function to be called when websocket reconnects and initialized, after ACK message returned from the server. Includes payload from server, if any.
 - `thisContext: any`: `this` context to use when calling the callback function.
 - => Returns an `off` method to cancel the event subscription.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -624,7 +624,7 @@ export class SubscriptionClient {
         break;
 
       case MessageTypes.GQL_CONNECTION_ACK:
-        this.eventEmitter.emit(this.reconnecting ? 'reconnected' : 'connected');
+        this.eventEmitter.emit(this.reconnecting ? 'reconnected' : 'connected', parsedMessage.payload);
         this.reconnecting = false;
         this.backoff.reset();
         this.maxConnectTimeGenerator.reset();

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -45,6 +45,8 @@ const ONCONNECT_ERROR_TEST_PORT = TEST_PORT + 6;
 const ERROR_TEST_PORT = TEST_PORT + 7;
 
 const SERVER_EXECUTOR_TESTS_PORT = ERROR_TEST_PORT + 8;
+const ACK_ONCONNECTED_TEST_PORT = TEST_PORT + 8;
+const ACK_ONRECONNECTED_TEST_PORT = TEST_PORT + 9;
 
 const data: { [key: string]: { [key: string]: string } } = {
   '1': {
@@ -733,13 +735,17 @@ describe('Client', function () {
   });
 
   it('should handle correctly GQL_CONNECTION_ACK payload for onConnected', (done) => {
-    wsServer.on('connection', (connection: any) => {
+    const server = createServer(notFoundRequestListener);
+    server.listen(ACK_ONCONNECTED_TEST_PORT);
+    const wss = new WebSocket.Server({server});
+    wss.on('connection', (connection: any) => {
       connection.on('message', (message: any) => {
         connection.send(JSON.stringify({ type: MessageTypes.GQL_CONNECTION_ACK, payload: {appVersion: '1.0.0'} }));
+        wss.close();
       });
     });
 
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    const client = new SubscriptionClient(`ws://localhost:${ACK_ONCONNECTED_TEST_PORT}/`);
     client.onConnected((payload) => {
       expect(payload.appVersion).to.equal('1.0.0');
       done();
@@ -747,13 +753,17 @@ describe('Client', function () {
   });
 
   it('should handle correctly GQL_CONNECTION_ACK payload for onReconnected', (done) => {
-    wsServer.on('connection', (connection: any) => {
+    const server = createServer(notFoundRequestListener);
+    server.listen(ACK_ONRECONNECTED_TEST_PORT);
+    const wss = new WebSocket.Server({server});
+    wss.on('connection', (connection: any) => {
       connection.on('message', (message: any) => {
         connection.send(JSON.stringify({ type: MessageTypes.GQL_CONNECTION_ACK, payload: {appVersion: '1.0.0'} }));
+        wss.close();
       });
     });
 
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, { reconnect: true });
+    const client = new SubscriptionClient(`ws://localhost:${ACK_ONRECONNECTED_TEST_PORT}/`, { reconnect: true });
     client.close(false, false);
     client.onReconnected((payload) => {
       expect(payload.appVersion).to.equal('1.0.0');

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -732,6 +732,35 @@ describe('Client', function () {
     });
   });
 
+  it('should handle correctly GQL_CONNECTION_ACK payload for onConnected', (done) => {
+    wsServer.on('connection', (connection: any) => {
+      connection.on('message', (message: any) => {
+        connection.send(JSON.stringify({ type: MessageTypes.GQL_CONNECTION_ACK, payload: {appVersion: '1.0.0'} }));
+      });
+    });
+
+    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    client.onConnected((payload) => {
+      expect(payload.appVersion).to.equal('1.0.0');
+      done();
+    });
+  });
+
+  it('should handle correctly GQL_CONNECTION_ACK payload for onReconnected', (done) => {
+    wsServer.on('connection', (connection: any) => {
+      connection.on('message', (message: any) => {
+        connection.send(JSON.stringify({ type: MessageTypes.GQL_CONNECTION_ACK, payload: {appVersion: '1.0.0'} }));
+      });
+    });
+
+    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, { reconnect: true });
+    client.close(false, false);
+    client.onReconnected((payload) => {
+      expect(payload.appVersion).to.equal('1.0.0');
+      done();
+    });
+  });
+
   it('removes subscription when it unsubscribes from it', function () {
     const client = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`);
 


### PR DESCRIPTION
Sometimes, it's nice to send a payload with an ACK.
A good example might be a JWT, in case the one the client is using is about to expire.
Another example might be the app version, which allows you to upgrade the client without requiring a refresh (this pairs nicely with the built-in reconnect logic).
 
I think you guys were thinking about doing this, too, because I noticed a payload field for ACKs already exists in the tests: https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/test/tests.ts#L282
