### PR TITLE
Updated dependency iterall to add support for flowtype v0.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "backo2": "^1.0.2",
     "eventemitter3": "^2.0.3",
-    "iterall": "^1.1.1",
+    "iterall": "^1.2.1",
     "lodash.assign": "^4.2.0",
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",


### PR DESCRIPTION
Currently this dependency throws an error with flowtype `v0.66`. A fix has been published to iterall `v1.2.1`