### PR TITLE
change default keep-alive setting from 10s to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### vNEXT
-- change default timeout from 10s to 30s(https://github.com/apollographql/subscriptions-transport-ws/issues/167)
+- change default timeout from 10s to 30s [PR #368](https://github.com/apollographql/subscriptions-transport-ws/pull/368)
 
 ### 0.9.6
 - fix shallow cloning on contexts which are classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- change default timeout from 10s to 30s(https://github.com/apollographql/subscriptions-transport-ws/issues/167)
 
 ### 0.9.6
 - fix shallow cloning on contexts which are classes

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ ReactDOM.render(
 ### `Constructor(url, options, connectionCallback)`
 - `url: string` : url that the client will connect to, starts with `ws://` or `wss://`
 - `options?: Object` : optional, object to modify default client behavior
-  * `timeout?: number` : how long the client should wait in ms for a keep-alive message from the server (default 10000 ms), this parameter is ignored if the server does not send keep-alive messages. This will also be used to calculate the max connection time per connect/reconnect
+  * `timeout?: number` : how long the client should wait in ms for a keep-alive message from the server (default 30000 ms), this parameter is ignored if the server does not send keep-alive messages. This will also be used to calculate the max connection time per connect/reconnect
   * `lazy?: boolean` : use to set lazy mode - connects only when first subscription created, and delay the socket initialization
   * `connectionParams?: Object | Function` : object that will be available as first argument of `onConnect` (in server side), if passed a function - it will call it and send the return value
   * `reconnect?: boolean` : automatic reconnect in case of connection error

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,4 +1,4 @@
-const WS_TIMEOUT = 10000;
+const WS_TIMEOUT = 30000;
 
 export {
   WS_TIMEOUT,


### PR DESCRIPTION
following the graphcool server setting. See: https://github.com/apollographql/subscriptions-transport-ws/issues/167

The problem described at https://www.graph.cool/forum/t/invoking-a-subscription-event-frequently-in-a-short-amount-of-time/1298/6?u=huan is not solved if the timeout is set to 10s.

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->