### PR TITLE
unclear 'publishes'

### DIFF
--- a/docs/source/external-pubsub.md
+++ b/docs/source/external-pubsub.md
@@ -6,6 +6,6 @@ title: Using an external PubSub Engine
 
 By default `graphql-subscriptions` exports an in-memory (`EventEmitter`) event system to re-run subscriptions.
 
-This is not suitable for running in a serious production app, because there is no way to share subscriptions and publishes across many running servers.
+This is not suitable for running in a serious production app, because there is no way to share subscriptions and publish across many running servers.
 
 [`graphql-subscriptions` - PubSub Implementations](https://github.com/apollographql/graphql-subscriptions#pubsub-implementations) lists existing external PubSub implementations.


### PR DESCRIPTION
Fixed a typo which I believe should be 'there is no way to share subscriptions and publish across...'

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->