### PR TITLE
fix: use plain JS code instead of lodash.isobject/lodash.isstring

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,8 +4,6 @@ const NativeWebSocket = _global.WebSocket || _global.MozWebSocket;
 
 import * as Backoff from 'backo2';
 import { default as EventEmitterType, EventEmitter, ListenerFn } from 'eventemitter3';
-import isString = require('lodash.isstring');
-import isObject = require('lodash.isobject');
 import { ExecutionResult } from 'graphql/execution/execute';
 import { print } from 'graphql/language/printer';
 import { DocumentNode } from 'graphql/language/ast';
@@ -389,9 +387,9 @@ export class SubscriptionClient {
     }
 
     if (
-      ( !isString(query) && !getOperationAST(query, operationName)) ||
-      ( operationName && !isString(operationName)) ||
-      ( variables && !isObject(variables))
+      ( typeof query !== 'string' && !getOperationAST(query, operationName)) ||
+      ( operationName && typeof operationName !== 'string') ||
+      ( variables && typeof variables !== 'object')
     ) {
       throw new Error('Incorrect option types. query must be a string or a document,' +
         '`operationName` must be a string, and `variables` must be an object.');

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,6 @@ import * as WebSocket from 'ws';
 
 import MessageTypes from './message-types';
 import { GRAPHQL_WS, GRAPHQL_SUBSCRIPTIONS } from './protocol';
-import isObject = require('lodash.isobject');
 import {
   parse,
   ExecutionResult,
@@ -314,7 +313,9 @@ export class SubscriptionServer {
               query: parsedMessage.payload.query,
               variables: parsedMessage.payload.variables,
               operationName: parsedMessage.payload.operationName,
-              context: isObject(initResult) ? Object.assign(Object.create(Object.getPrototypeOf(initResult)), initResult) : {},
+              context: initResult && typeof initResult === 'object'
+                ? Object.assign(Object.create(Object.getPrototypeOf(initResult)), initResult)
+                : {},
               formatResponse: <any>undefined,
               formatError: <any>undefined,
               callback: <any>undefined,
@@ -475,4 +476,3 @@ export class SubscriptionServer {
     );
   }
 }
-

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -2,19 +2,4 @@ interface Array<T> {
   indexOfField : (propertyName: string, value: any) => number;
 }
 
-declare module 'lodash.assign' {
-  import {assign} from 'lodash';
-  export = assign;
-}
-
-declare module 'lodash.isobject' {
-  import {isObject} from 'lodash';
-  export = isObject;
-}
-
-declare module 'lodash.isstring' {
-  import {isString} from 'lodash';
-  export = isString;
-}
-
 declare module 'backo2';


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

The use was pretty unnecessary.  People seem to think they need these functions without deeply understanding what they do, and without realizing their primary purpose is to be passed as predicates to functions like `_.some` etc. instead of merely being used in place of `typeof thing === 'string'`.

Note that `isObject` accepts functions, but the code I replaced it with (`foo && typeof foo === 'object'`) does not.  However I think it was accidental to accept a function for `variables` and it would probably be equally accidental if someone is passing a function there.  This code will still accept `RegExp`s, `Arrays`, and non-plain JS objects for `variables` though, just like the current code does :wink:
`isString` accepts not only primitive strings but also the funky `String` wrapper objects, but I don't think anyone uses those intentionally.  And if they do it's probably for some even more funky hack that relies on tacking properties onto the `String` wrapper.