### PR TITLE
Fix duplicate subscription after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- applies fix suggested by @pandemosth regarding "No subscription is made on reconnect" and "Duplicate subscription made on reconnect" described in [Issue #295](https://github.com/apollographql/subscriptions-transport-ws/issues/295#issuecomment-398184429)
 
 ### v0.9.11
 - allow using custom WebSocket server implementation [PR #374](https://github.com/apollographql/subscriptions-transport-ws/pull/374)

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -241,6 +241,14 @@ new SubscriptionServer(Object.assign({}, options, {
 const httpServerRaw = createServer(notFoundRequestListener);
 httpServerRaw.listen(RAW_TEST_PORT);
 
+function sleep(time: number) {
+  const stop = new Date().getTime();
+
+  while (new Date().getTime() < stop + time) {
+    // nothing
+  }
+}
+
 describe('Client', function () {
 
   let wsServer: WebSocket.Server;
@@ -267,6 +275,47 @@ describe('Client', function () {
     });
 
     new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+  });
+
+  it('should subscribe once after reconnect', (done) => {
+    let isClientReconnected = false;
+    let subscriptionsCount = 0;
+
+    wsServer.on('headers', () => {
+      if (!isClientReconnected) {
+        isClientReconnected = true;
+        sleep(1100);
+      }
+    });
+
+    wsServer.on('connection', (connection: any) => {
+      connection.on('message', (message: any) => {
+        const parsedMessage = JSON.parse(message);
+
+        if (parsedMessage.type === MessageTypes.GQL_START) {
+          subscriptionsCount++;
+        }
+      });
+    });
+
+    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+      reconnect: true,
+      reconnectionAttempts: 1,
+    });
+
+    client.request({
+      query: `subscription useInfo {
+        user(id: 3) {
+          id
+          name
+        }
+      }`,
+    }).subscribe({});
+
+    setTimeout(() => {
+      expect(subscriptionsCount).to.be.equal(1);
+      done();
+    }, 1500);
   });
 
   it('should send GQL_CONNECTION_INIT message first, then the GQL_START message', (done) => {


### PR DESCRIPTION
Same patch as in https://github.com/apollographql/subscriptions-transport-ws/pull/428 but with test.