### PR TITLE
docs: Update blog URLs to reference blog.apollographql.com.

### DIFF
--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -100,7 +100,7 @@ ws.listen(PORT, () => {
 
 ```
 
-See [the tutorial on Medium for complete working sample code](https://dev-blog.apollodata.com/tutorial-graphql-subscriptions-server-side-e51c32dc2951).
+See [the tutorial on Medium for complete working sample code](https://blog.apollographql.com/tutorial-graphql-subscriptions-server-side-e51c32dc2951).
 
 <h2 id="subscription-resolver">Subscription Resolver</h2>
 


### PR DESCRIPTION
This updates all blog URLs in the documentation to use blog.apollographql.com
as the domain, rather than dev-blog.apollodata.com.