### PR TITLE
Allow dynamic schema resolution 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Allow dynamically specifying/overriding the schema in the object returned from `onOperation` [PR #447](https://github.com/apollographql/subscriptions-transport-ws/pull/447)
 
 ### v0.9.12
 - use lightweight lodash alternatives [Issue #430](https://github.com/apollographql/subscriptions-transport-ws/issues/430)

--- a/README.md
+++ b/README.md
@@ -303,10 +303,10 @@ ReactDOM.render(
 ### `Constructor(options, socketOptions | socketServer)`
 - `options: {ServerOptions}`
   * `rootValue?: any` : Root value to use when executing GraphQL root operations
-  * `schema?: GraphQLSchema` : GraphQL schema object
+  * `schema?: GraphQLSchema` : GraphQL schema object. If not provided, you have to return the schema as a property on the object returned from `onOperation`.
   * `execute?: (schema, document, rootValue, contextValue, variableValues, operationName) => Promise<ExecutionResult> | AsyncIterator<ExecutionResult>` : GraphQL `execute` function, provide the default one from `graphql` package. Return value of `AsyncItrator` is also valid since this package also support reactive `execute` methods.
   * `subscribe?: (schema, document, rootValue, contextValue, variableValues, operationName) => Promise<ExecutionResult | AsyncIterator<ExecutionResult>>` : GraphQL `subscribe` function, provide the default one from `graphql` package.
-  * `onOperation?: (message: SubscribeMessage, params: SubscriptionOptions, webSocket: WebSocket)` : optional method to create custom params that will be used when resolving this operation
+  * `onOperation?: (message: SubscribeMessage, params: SubscriptionOptions, webSocket: WebSocket)` : optional method to create custom params that will be used when resolving this operation. It can also be used to dynamically resolve the schema that will be used for the particular operation.
   * `onOperationComplete?: (webSocket: WebSocket, opId: string)` : optional method that called when a GraphQL operation is done (for query and mutation it's immediately, and for subscriptions when unsubscribing)
   * `onConnect?: (connectionParams: Object, webSocket: WebSocket, context: ConnectionContext)` : optional method that called when a client connects to the socket, called with the `connectionParams` from the client, if the return value is an object, its elements will be added to the context. return `false` or throw an exception to reject the connection. May return a Promise.
   * `onDisconnect?: (webSocket: WebSocket, context: ConnectionContext)` : optional method that called when a client disconnects

--- a/docs/source/lifecycle-events.md
+++ b/docs/source/lifecycle-events.md
@@ -6,7 +6,7 @@ title: Lifecycle Events
 
 * `onConnect` - called upon client connection, with the `connectionParams` passed to `SubscriptionsClient` - you can return a Promise and reject the connection by throwing an exception. The resolved return value will be appended to the GraphQL `context` of your subscriptions.
 * `onDisconnect` - called when the client disconnects.
-* `onOperation` - called when the client executes a GraphQL operation - use this method to create custom params that will be used when resolving the operation.
+* `onOperation` - called when the client executes a GraphQL operation - use this method to create custom params that will be used when resolving the operation. You can use this method to override the GraphQL schema that will be used in the operation.
 * `onOperationComplete` - called when client's operation has been done it's execution (for subscriptions called when unsubscribe, and for query/mutation called immediately).
 
 ```js
@@ -16,7 +16,15 @@ const subscriptionsServer = new SubscriptionServer(
       // ...
     },
     onOperation: (message, params, webSocket) => {
-      // ...
+      // Manipulate and return the params, e.g.
+      params.context.randomId = uuid.v4();
+
+      // Or specify a schema override
+      if (shouldOverrideSchema()) {
+        params.schema = newSchema;
+      }
+
+      return params;
     },
     onOperationComplete: webSocket => {
       // ...

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1789,7 +1789,7 @@ describe('Server', function () {
       client1.unsubscribeAll();
       expect(numResults1).to.equals(1);
       done();
-    }, 300);
+    }, 400);
 
   });
 

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1322,10 +1322,81 @@ describe('Server', function () {
     }).to.throw();
   });
 
-  it('should throw an exception when using execute but schema is missing', () => {
-    expect(() => {
-      new SubscriptionServer({ execute: {} as any }, { server: httpServer });
-    }).to.throw();
+  it('should throw an exception when schema is not provided', (done) => {
+    server = createServer(notFoundRequestListener);
+    server.listen(SERVER_EXECUTOR_TESTS_PORT);
+
+    SubscriptionServer.create({
+      execute,
+    }, {
+      server,
+      path: '/',
+    });
+
+    let errorMessage: string;
+
+    const client = new SubscriptionClient(`ws://localhost:${SERVER_EXECUTOR_TESTS_PORT}/`);
+    client.onConnected(() => {
+      client.request({
+        query: `query { testString }`,
+        variables: {},
+      }).subscribe({
+        next: (res) => {
+          assert(false, 'expected error to be thrown');
+        },
+        error: (err) => {
+          errorMessage = err.message;
+          expect(errorMessage).to.contain('Missing schema information');
+          done();
+        },
+        complete: () => {
+          assert(false, 'expected error to be thrown');
+        },
+      });
+    });
+  });
+
+  it('should use schema provided in onOperation', (done) => {
+    server = createServer(notFoundRequestListener);
+    server.listen(SERVER_EXECUTOR_TESTS_PORT);
+
+    SubscriptionServer.create({
+      execute,
+      onOperation: () => {
+        return {
+          schema
+        };
+      },
+    }, {
+      server,
+      path: '/',
+    });
+
+    let msgCnt = 0;
+
+    const client = new SubscriptionClient(`ws://localhost:${SERVER_EXECUTOR_TESTS_PORT}/`);
+    client.onConnected(() => {
+      client.request({
+        query: `query { testString }`,
+        variables: {},
+      }).subscribe({
+        next: (res) => {
+          if ( res.errors ) {
+            assert(false, 'unexpected error from request');
+          }
+
+          expect(res.data).to.deep.equal({ testString: 'value' });
+          msgCnt ++;
+        },
+        error: (err) => {
+          assert(false, 'unexpected error from request');
+        },
+        complete: () => {
+          expect(msgCnt).to.equals(1);
+          done();
+        },
+      });
+    });
   });
 
   it('should accept execute method than returns a Promise (original execute)', (done) => {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1364,7 +1364,7 @@ describe('Server', function () {
       execute,
       onOperation: () => {
         return {
-          schema
+          schema,
         };
       },
     }, {


### PR DESCRIPTION
Sometimes, the GraphQL schema needs to be dynamically resolved (e.g. when exposing a database interface). This change allows the schema to be provided either as a static value or as a function of the connection context:

```ts
const subscriptionServer = new SubscriptionServer(
{
    schema: undefined,
    onOperation: async (message, params, socket) => {
        if (await something()) {
            params.schema = schema1;
        } else {
            params.schema = schema2;
        }

        return params;
    },
    ...
}
```

There are no tests for it since it's a fairly trivial change and I wasn't sure if it would be accepted, but I can write some smoke tests if required.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->