### PR TITLE
Fix console error

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -377,7 +377,7 @@ export class SubscriptionServer {
                     try {
                       result = params.formatResponse(value, params);
                     } catch (err) {
-                      console.error('Error in formatError function:', err);
+                      console.error('Error in formatResponse function:', err);
                     }
                   }
 


### PR DESCRIPTION
Message blames `formatError` for the failings of `formatResponse`.
