### PR TITLE
PROTOCOL.md doc improvements

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -23,10 +23,12 @@ Client sends this message after plain websocket connection to start the communic
 
 The server will response only with `GQL_CONNECTION_ACK` + `GQL_CONNECTION_KEEP_ALIVE` (if used) or `GQL_CONNECTION_ERROR` to this message.
 
+- `type: "connection_init"`
 - `payload: Object` : optional parameters that the client specifies in `connectionParams`
 
 #### GQL_START
 Client sends this message to execute GraphQL operation
+- `type: "start"`
 - `id: string` : The id of the GraphQL operation to start
 - `payload: Object`:
     * `query: string` : GraphQL operation as string or parsed GraphQL document node
@@ -35,10 +37,12 @@ Client sends this message to execute GraphQL operation
     
 #### GQL_STOP
 Client sends this message in order to stop a running GraphQL operation execution (for example: unsubscribe)
+- `type: "stop"`
 - `id: string` : operation id
     
 #### GQL_CONNECTION_TERMINATE
 Client sends this message to terminate the connection.    
+- `type: "connection_terminate"`
     
 ### Server -> Client
 
@@ -47,17 +51,20 @@ The server may responses with this message to the `GQL_CONNECTION_INIT` from cli
 
 It server also respond with this message in case of a parsing errors of the message (which does not disconnect the client, just ignore the message).
 
+- `type: "connection_error"`
 - `payload: Object`: the server side error
 
 #### GQL_CONNECTION_ACK
 The server may responses with this message to the `GQL_CONNECTION_INIT` from client, indicates the server accepted the connection.
 
+- `type: "connection_ack"`
 
 #### GQL_DATA
 The server sends this message to transfter the GraphQL execution result from the server to the client, this message is a response for `GQL_START` message.
 
 For each GraphQL operation send with `GQL_START`, the server will respond with at least one `GQL_DATA` message.
 
+- `type: "data"`
 - `id: string` : ID of the operation that was successfully set up
 - `payload: Object` : 
     * `data: any`: Execution result
@@ -65,18 +72,22 @@ For each GraphQL operation send with `GQL_START`, the server will respond with a
 
 #### GQL_ERROR
 Server sends this message upon a failing operation, before the GraphQL execution, usually due to GraphQL validation errors (resolver errors are part of `GQL_DATA` message, and will be added as `errors` array)
+- `type: "error"`
 - `payload: Error` : payload with the error attributed to the operation failing on the server
 - `id: string` : operation ID of the operation that failed on the server
 
 #### GQL_COMPLETE
 Server sends this message to indicate that a GraphQL operation is done, and no more data will arrive for the specific operation.
 
+- `type: "complete"`
 - `id: string` : operation ID of the operation that completed
 
 #### GQL_CONNECTION_KEEP_ALIVE
 Server message that should be sent right after each `GQL_CONNECTION_ACK` processed and then periodically to keep the client connection alive.
 
 The client starts to consider the keep alive message only upon the first received keep alive message from the server.
+
+- `type: "ka"`
 
 ### Messages Flow
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -107,14 +107,17 @@ The phase initializes the connection between the client and server, and usually 
 This phase called per each operation the client request to execute:
 
 - App creates a subscription using `subscribe` or `query` client's API, and the `GQL_START` message sent to the server.
-- Server calls `onOperation` callback, and responds with `GQL_DATA` in case of zero errors, or `GQL_ERROR` if there is a problem with the operation (is might also return `GQL_ERROR` with `errors` array, in case of resolvers errors).
-- Client get `GQL_DATA` and handles it.
+- Server calls `onOperation` callback, and responds with:
+    - if there are zero errors: `GQL_DATA`
+    - if there are resolver errors: `GQL_DATA` with `errors` array
+    - if there is a problem with the operation: `GQL_ERROR`
+- Client receives `GQL_DATA` or `GQL_ERROR` and handles it.
 - Server calls `onOperationDone` if the operation is a query or mutation (for subscriptions, this called when unsubscribing)
 - Server sends `GQL_COMPLETE` if the operation is a query or mutation (for subscriptions, this sent when unsubscribing)
 
 For subscriptions:
 - App triggers `PubSub`'s publication method, and the server publishes the event, passing it through the `subscribe` executor to create GraphQL execution result
 - Client receives `GQL_DATA` with the data, and handles it.
-- When client unsubscribe, the server triggers `onOperationDone` and sends `GQL_COMPLETE` message to the client.
+- When client unsubscribe (by sending a `GQL_STOP` message), the server triggers `onOperationDone` and sends `GQL_COMPLETE` message to the client.
 
 When client done with executing GraphQL, it should close the connection and terminate the session using `GQL_CONNECTION_TERMINATE` message.


### PR DESCRIPTION
I have been looking at integrating the Apollo WebSocket protocol in a non-Node.js project and have been playing around with the GitHunt-API example project.  Figured I'd update `PROTOCOL.md` with some of my findings.

I have a few parts I'm not 100% sure about:

1. In the case of resolver errors, previously the docs said that `GQL_START` might 

    > "also return `GQL_ERROR` with `errors` array, in case of resolvers errors"

    From my testing with the GitHunt sample project, I believe it is actually `GQL_DATA` that is returned with an `errors` array.  Is `GQL_DATA` correct?

2. If a `GQL_START` results in a `GQL_ERROR`, should the client also receive a `GQL_COMPLETE`?  

3. Digging through the code, I see that `GQL_ERROR` (and `GQL_CONNECTION_ERROR`?) usually have a `payload` with a `message` field.  Do you think it's worth me adding it into the docs somehow?

I was wondering if anyone had any insight into the above questions.  I will update the docs to reflect the answers.  Thanks!

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

**TODO:**

- ~Make sure all of the significant new logic is covered by tests~ (no code changes)
- [x] Rebase your changes on master so that they can be merged easily
- ~Make sure all tests and linter rules pass~ (no code changes)
- ~Update CHANGELOG.md with your change~ (no code changes)

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->