### PR TITLE
Add ability to set custom WebSocket protocols in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add support for `graphql` and `@types/graphql` 14.  <br/>
   [@caiquecastro](https://github.com/caiquecastro) in [#464](https://github.com/apollographql/subscriptions-transport-ws/pull/464)
+- Add ability to set custom WebSocket protocols for client. <br/>
+  [@pkosiec](https://github.com/pkosiec) in [#477](https://github.com/apollographql/subscriptions-transport-ws/pull/477)
 
 ### v0.9.14
 - Allow dynamically specifying/overriding the schema in the object returned from `onOperation` [PR #447](https://github.com/apollographql/subscriptions-transport-ws/pull/447)

--- a/src/client.ts
+++ b/src/client.ts
@@ -87,6 +87,7 @@ export class SubscriptionClient {
   private inactivityTimeoutId: any;
   private closedByUser: boolean;
   private wsImpl: any;
+  private wsProtocols: string | string[];
   private wasKeepAliveReceived: boolean;
   private tryReconnectTimeoutId: any;
   private checkConnectionIntervalId: any;
@@ -94,7 +95,12 @@ export class SubscriptionClient {
   private middlewares: Middleware[];
   private maxConnectTimeGenerator: any;
 
-  constructor(url: string, options?: ClientOptions, webSocketImpl?: any) {
+  constructor(
+    url: string,
+    options?: ClientOptions,
+    webSocketImpl?: any,
+    webSocketProtocols?: string | string[],
+  ) {
     const {
       connectionCallback = undefined,
       connectionParams = {},
@@ -106,11 +112,11 @@ export class SubscriptionClient {
     } = (options || {});
 
     this.wsImpl = webSocketImpl || NativeWebSocket;
-
     if (!this.wsImpl) {
       throw new Error('Unable to find native implementation, or alternative implementation for WebSocket!');
     }
 
+    this.wsProtocols = webSocketProtocols || GRAPHQL_WS;
     this.connectionCallback = connectionCallback;
     this.url = url;
     this.operations = {};
@@ -536,7 +542,7 @@ export class SubscriptionClient {
   }
 
   private connect() {
-    this.client = new this.wsImpl(this.url, GRAPHQL_WS);
+    this.client = new this.wsImpl(this.url, this.wsProtocols);
 
     this.checkMaxConnectTimeout();
 

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1322,6 +1322,17 @@ describe('Client', function () {
       }, 50);
     }, 50);
   });
+
+  it('should allow passing custom WebSocket protocols', () => {
+    const testCases = ['custom-protocol', ['custom', 'protocols']];
+
+    for (const testCase of testCases) {
+      const mockWebSocket = sinon.spy();
+      new SubscriptionClient(`ws://localhost:${TEST_PORT}`, {}, mockWebSocket, testCase);
+      expect(mockWebSocket.calledOnce).to.be.true;
+      expect(mockWebSocket.firstCall.args[1]).to.equal(testCase);
+    }
+  });
 });
 
 describe('Server', function () {


### PR DESCRIPTION
Hello,
I'm using the library on my front-end application and I would like to have the ability to set custom WebSocket protocols for client.

I've seen an existing issue with this feature request - that's why I'm opening this PR. Hope you'll like it!

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Resolves #404 