### PR TITLE
@types/ws is a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git+https://github.com/apollostack/subscriptions-transport-ws.git"
   },
   "dependencies": {
+    "@types/ws": "^5.1.2",
     "backo2": "^1.0.2",
     "eventemitter3": "^3.1.0",
     "iterall": "^1.2.1",
@@ -40,7 +41,6 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.8",
     "@types/sinon": "^5.0.1",
-    "@types/ws": "^5.1.2",
     "chai": "^4.0.2",
     "graphql": "^14.0.2",
     "graphql-subscriptions": "^1.0.0",


### PR DESCRIPTION
`@types/ws` is actually a dependency of the library since users of the library will see TypeScript compilation errors without it:
```
node_modules/subscriptions-transport-ws/dist/server.d.ts:2:28 - error TS7016: Could not find a declaration file for module 'ws'. '/Users/skainswo/dev/kumo/node-api/node_modules/ws/index.js' implicitly has an 'any' type.
  Try `npm install @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`

2 import * as WebSocket from 'ws';
                             ~~~~
```

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.

