### PR TITLE
Fix type definition in connection callback (synchronized with doc)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -63,7 +63,7 @@ export interface ClientOptions {
   timeout?: number;
   reconnect?: boolean;
   reconnectionAttempts?: number;
-  connectionCallback?: (error: Error[], result?: any) => void;
+  connectionCallback?: (error?: Error) => void;
   lazy?: boolean;
   inactivityTimeout?: number;
 }
@@ -80,7 +80,7 @@ export class SubscriptionClient {
   private reconnecting: boolean;
   private reconnectionAttempts: number;
   private backoff: any;
-  private connectionCallback: any;
+  private connectionCallback: (error?: Error) => void;
   private eventEmitter: EventEmitterType;
   private lazy: boolean;
   private inactivityTimeout: number;


### PR DESCRIPTION
Hi, I found mistake in Client definition with typescript.
`connectionCallback` in `ClientOptions` should have signature: `(error?: Error) => void;`

documentation:
https://github.com/apollographql/subscriptions-transport-ws/blame/master/README.md#L244
client type definition:
https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/client.ts#L66
