### PR TITLE
Inline sources contents in source map files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   [@renatorib](https://github.com/renatorib) in [#761](https://github.com/apollographql/subscriptions-transport-ws/pull/761)
 - Destructure the correct error object in `MessageTypes.GQL_START`.  <br/>
   [@gregbty](https://github.com/gregbty) in [#588](https://github.com/apollographql/subscriptions-transport-ws/pull/588)
+- Inline source in sourcemap files to fix broken source lookups.  <br/>
+  [@alexkirsz](https://github.com/alexkirsz) in [#513](https://github.com/apollographql/subscriptions-transport-ws/pull/513)
 
 ### New Features
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "noImplicitAny": true,
     "rootDir": "./src",
     "outDir": "./dist",


### PR DESCRIPTION
Changes proposed in this pull request:

- Inline sources contents in source map files. 

The current behavior is for `.map` files to refer to the source file. The issue is that the `src` directory is not part of the NPM package, which makes this package's source maps useless as they point to non-existent files. This causes a lot of warnings with `source-map-loader`.

This proposed change makes it so the content of source files gets inlined in the `.map` files, so there is no actual need to read the source files.

Another way to do this would be to bundle the `src` directory within the NPM package.