### PR TITLE
Don't handle promisedParams error twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [@tretne](https://github.com/tretne) in [#615](https://github.com/apollographql/subscriptions-transport-ws/pull/615)
 - Fix `MessageTypes` TS import errors.  <br/>
   [@sneko](https://github.com/sneko) in [#412](https://github.com/apollographql/subscriptions-transport-ws/issues/412)
+- Ensure `promisedParams` errors are not handled twice.  <br/>
+  [@benjie](https://github.com/benjie) in [#514](https://github.com/apollographql/subscriptions-transport-ws/pull/514)
 
 ### New Features
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -329,7 +329,7 @@ export class SubscriptionServer {
               promisedParams = Promise.resolve(this.onOperation(messageForCallback, baseParams, connectionContext.socket));
             }
 
-            promisedParams.then((params) => {
+            return promisedParams.then((params) => {
               if (typeof params !== 'object') {
                 const error = `Invalid params returned from onOperation! return values must be an object!`;
                 this.sendError(connectionContext, opId, { message: error });
@@ -425,7 +425,6 @@ export class SubscriptionServer {
               this.unsubscribe(connectionContext, opId);
               return;
             });
-            return promisedParams;
           }).catch((error) => {
             // Handle initPromise rejected
             this.sendError(connectionContext, opId, { message: error.message });


### PR DESCRIPTION
If `promisedParams` resolves to an exception then the error will be handled twice; once here:

https://github.com/apollographql/subscriptions-transport-ws/blob/34d503a6cef99efaffb35dae6a816ab898440565/src/server.ts#L418-L425

and once here:

https://github.com/apollographql/subscriptions-transport-ws/blob/34d503a6cef99efaffb35dae6a816ab898440565/src/server.ts#L430-L432

this PR resolves that issue. It's a very minor fix, so shouldn't require any test changes.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

