### PR TITLE
feat: make tryReconnect public and include willTryReconnectAt in disconnected event

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,12 +277,15 @@ ReactDOM.render(
 - => Returns an `off` method to cancel the event subscription.
 
 #### `onReconnecting(callback, thisContext) => Function` - shorthand for `.on('reconnecting', ...)`
-- `callback: Function`: function to be called when websocket starts it's reconnection 
+- `callback: Function`: function to be called when websocket starts it's reconnection
 - `thisContext: any`: `this` context to use when calling the callback function.
 - => Returns an `off` method to cancel the event subscription.
 
 #### `onDisconnected(callback, thisContext) => Function` - shorthand for `.on('disconnected', ...)`
 - `callback: Function`: function to be called when websocket disconnected.
+  it will be called with an object with `{willTryReconnectAt?: number}` with the
+  timestamp at which it will next try to reconnect (or `null` if it will not try
+  to reconnect again).
 - `thisContext: any`: `this` context to use when calling the callback function.
 - => Returns an `off` method to cancel the event subscription.
 
@@ -292,6 +295,8 @@ ReactDOM.render(
 - => Returns an `off` method to cancel the event subscription.
 
 ### `close() => void` - closes the WebSocket connection manually, and ignores `reconnect` logic if it was set to `true`.
+
+### `tryReconnect() => void` - tries to reconnect if the client isn't already connected.
 
 ### `use(middlewares: MiddlewareInterface[]) => SubscriptionClient` - adds middleware to modify `OperationOptions` per each request
 - `middlewares: MiddlewareInterface[]` - Array contains list of middlewares (implemented `applyMiddleware` method) implementation, the `SubscriptionClient` will use the middlewares to modify `OperationOptions` for every operation


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

fix #517 

Help!  How do I pass an object through to the event listeners?  The tests seem to indicate
that the connection context is passed as an argument instead of the this binding, which is
bizarre and I can't find where in the code it does that.