### PR TITLE
Use GraphQL syntax in codeblocks

### DIFF
--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -118,7 +118,7 @@ To do so, we can use `withFilter` helper from this package, which wraps `AsyncIt
 
 Let's see an example - for the `commentAdded` server-side subscription, the client want to subscribe only to comments added to a specific repo:
 
-```
+```graphql
 subscription($repoName: String!){
   commentAdded(repoFullName: $repoName) {
     id

--- a/docs/source/subscriptions-to-schema.md
+++ b/docs/source/subscriptions-to-schema.md
@@ -8,7 +8,7 @@ You specify operation type, then the operation name and you can customize the pu
 
 You need to create a root schema definition and a root resolver for your `Subscription` root, just like with Query and Mutation:
 
-```
+```graphql
 type Comment {
     id: String
     content: String

--- a/docs/source/subscriptions-to-schema.md
+++ b/docs/source/subscriptions-to-schema.md
@@ -10,8 +10,8 @@ You need to create a root schema definition and a root resolver for your `Subscr
 
 ```graphql
 type Comment {
-    id: String
-    content: String
+  id: String
+  content: String
 }
 
 type Subscription {


### PR DESCRIPTION
This branch updates two pages in the docs to use graphql syntax highlighting in the appropriate places
