### PR TITLE
Add src files for source-maps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,5 +8,4 @@ dist/test/
 docs/
 npm-debug.log.*
 package-lock.json
-src/
 yarn.lock


### PR DESCRIPTION
An alternative to this would be #513. Both fix the problem of source maps pointing into the void

This lets the current source maps point to a valid file instead of the void

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

