### PR TITLE
 add option to pass extra websocket client arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - Add `minTimeout` option for client.  <br/>
   [@jedwards1211](https://github.com/jedwards1211) in [#675](https://github.com/apollographql/subscriptions-transport-ws/pull/675)
+- Accept extra WebSocket client arguments.  <br/>
+  [@GingerBear](https://github.com/GingerBear) in [#561](https://github.com/apollographql/subscriptions-transport-ws/pull/561)
 
 ## v0.9.17
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,6 +67,7 @@ export interface ClientOptions {
   connectionCallback?: (error: Error[], result?: any) => void;
   lazy?: boolean;
   inactivityTimeout?: number;
+  wsOptionArguments?: any[];
 }
 
 export class SubscriptionClient {
@@ -96,6 +97,7 @@ export class SubscriptionClient {
   private maxConnectTimeoutId: any;
   private middlewares: Middleware[];
   private maxConnectTimeGenerator: any;
+  private wsOptionArguments: any[];
 
   constructor(
     url: string,
@@ -112,6 +114,7 @@ export class SubscriptionClient {
       reconnectionAttempts = Infinity,
       lazy = false,
       inactivityTimeout = 0,
+      wsOptionArguments = [],
     } = (options || {});
 
     this.wsImpl = webSocketImpl || NativeWebSocket;
@@ -139,6 +142,7 @@ export class SubscriptionClient {
     this.client = null;
     this.maxConnectTimeGenerator = this.createMaxConnectTimeGenerator();
     this.connectionParams = this.getConnectionParams(connectionParams);
+    this.wsOptionArguments = wsOptionArguments;
 
     if (!this.lazy) {
       this.connect();
@@ -550,7 +554,7 @@ export class SubscriptionClient {
   }
 
   private connect() {
-    this.client = new this.wsImpl(this.url, this.wsProtocols);
+    this.client = new this.wsImpl(this.url, this.wsProtocols, ...this.wsOptionArguments);
 
     this.checkMaxConnectTimeout();
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change (not sure how to change)

Two of the most used websocket node implementation both support 3rd or more arguments to the constructor. Referring to [ws doc](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketaddress-protocols-options) and [WebSocket-Node doc](https://github.com/theturtle32/WebSocket-Node/blob/master/docs/W3CWebSocket.md#constructor)

This PR try adding an extra property to `ClientOptions` that can be used to pass extra arguments to the custom ws implementation. 
