### PR TITLE
Made reference to the values in message_types.ts

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2,7 +2,8 @@
 
 ## Client-server communication
 
-Each message has a `type` field, which defined in the protocol of this package, as well as associated fields inside `payload` field, depending on the message type, and `id` field so the client can identify each response from the server.
+Each message has a `type` field, the value of which is defined in the [message-types.ts](https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/message-types.ts) source file of this package. 
+Depending on the message type, it also has the associated fields inside the `payload` field, and an `id` field so the client can identify each response from the server.
 
 Each WebSocket message is represented in JSON structure, and being stringified before sending it over the network.
 


### PR DESCRIPTION
This needs to state that the connection enums in the type variable are located in the source and are not "GQL_CONNECTION_ACK", "GQL_CONNECTION_KEEP_ALIVE", etc.

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [] Update CHANGELOG.md with your change

