### PR TITLE
Destructure the correct error object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   [@benjie](https://github.com/benjie) in [#514](https://github.com/apollographql/subscriptions-transport-ws/pull/514)
 - Fix invalid `formatResponse` console error.  <br/>
   [@renatorib](https://github.com/renatorib) in [#761](https://github.com/apollographql/subscriptions-transport-ws/pull/761)
+- Destructure the correct error object in `MessageTypes.GQL_START`.  <br/>
+  [@gregbty](https://github.com/gregbty) in [#588](https://github.com/apollographql/subscriptions-transport-ws/pull/588)
 
 ### New Features
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -400,8 +400,8 @@ export class SubscriptionServer {
                   }
 
                   // plain Error object cannot be JSON stringified.
-                  if (Object.keys(e).length === 0) {
-                    error = { name: e.name, message: e.message };
+                  if (Object.keys(error).length === 0) {
+                    error = { name: error.name, message: error.message };
                   }
 
                   this.sendError(connectionContext, opId, error);


### PR DESCRIPTION
The incorrect error was being returned instead of the one that was returned from `formatError`. This also supports https://github.com/apollographql/apollo-server/pull/2942.

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

