### PR TITLE
Add optional onResult parameter to the request method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.9.17
+- Pass optional `onResult` callback to `request` method. [PR #687](https://github.com/apollographql/subscriptions-transport-ws/pull/687) <br/>
+  [@yelnar](https://github.com/yelnar)
+
 ### v0.9.16
 - Add ability to set custom WebSocket protocols for client. <br/>
   [@pkosiec](https://github.com/pkosiec) in [#477](https://github.com/apollographql/subscriptions-transport-ws/pull/477)

--- a/src/client.ts
+++ b/src/client.ts
@@ -203,9 +203,10 @@ export class SubscriptionClient {
             }
           } else {
             if ( observer.next ) {
-              observer.next(result);
               if (onResult) {
                 onResult(result);
+              } else {
+                observer.next(result);
               }
             }
           }

--- a/src/client.ts
+++ b/src/client.ts
@@ -172,7 +172,7 @@ export class SubscriptionClient {
     }
   }
 
-  public request(request: OperationOptions): Observable<ExecutionResult> {
+  public request(request: OperationOptions, onResult?: (result: any) => any): Observable<ExecutionResult> {
     const getObserver = this.getObserver.bind(this);
     const executeOperation = this.executeOperation.bind(this);
     const unsubscribe = this.unsubscribe.bind(this);
@@ -204,6 +204,9 @@ export class SubscriptionClient {
           } else {
             if ( observer.next ) {
               observer.next(result);
+              if (onResult) {
+                onResult(result);
+              }
             }
           }
         });


### PR DESCRIPTION
Hello.

I want to process subscription data before it hits `onSubscriptionData` callback.

Particularly in my case, I am sending data to the worker via `postMessage`.
If I call `postMessage` inside `onSubscriptionData` callback my application will perform poorly because I have huge amount of streamed data coming from the server.

To solve this issue I added optional `onResult` parameter which will be called whenever there is a subscription result.

Thanks.

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

