### PR TITLE
Support persisted queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v0.9.17
+- Don't pass query in payload if persistedQuery is given
+- Allow query to be returned from `onOperation`
+- Allow query not to be given, if `persistedQuery` is passed in payload
+
 ### v0.9.16
 - Add ability to set custom WebSocket protocols for client. <br/>
   [@pkosiec](https://github.com/pkosiec) in [#477](https://github.com/apollographql/subscriptions-transport-ws/pull/477)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscriptions-transport-ws",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "A websocket transport for GraphQL subscriptions",
   "main": "dist/index.js",
   "browser": "dist/client.js",

--- a/src/utils/empty-iterable.ts
+++ b/src/utils/empty-iterable.ts
@@ -1,6 +1,6 @@
 import { $$asyncIterator } from 'iterall';
 
-export const createEmptyIterable = (): AsyncIterator<any> => {
+export const createEmptyIterable = (): AsyncIterator<any> & { [$$asyncIterator]: () => AsyncIterator<any> } => {
   return {
     next() {
       return Promise.resolve({ value: undefined, done: true });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Currently, although there is reference to persisted queries in the past in this repo, the client does not support the `persistedQuery` extension. When a persisted query is provided, the original query is also sent along side the `persistedQuery`, defeating the purpose.

This PR allows persistedQuery's to be transported over websocket by:

- Not passing the `query` in the payload if a persisted query is given
- Allowing a request to be made without a query
- Allowing `onOperation` on the server-side to provide the query back, as `apollo-server` should be doing the decoding.

The reasons for this are outlined here: https://github.com/apollographql/apollo-link-persisted-queries/issues/18#issuecomment-623035052

If this PR goes through, I will do the work required on `apollo-server` to give support to apollo-server for this change.

This change should not be breaking.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

