### PR TITLE
Prevent messages from being sent when the client is closing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### v0.9.17
+- Prevent messages being sent when the client is closing. <br/>
+
 ### v0.9.16
 - Add ability to set custom WebSocket protocols for client. <br/>
   [@pkosiec](https://github.com/pkosiec) in [#477](https://github.com/apollographql/subscriptions-transport-ws/pull/477)

--- a/src/client.ts
+++ b/src/client.ts
@@ -461,9 +461,13 @@ export class SubscriptionClient {
   }
 
   // send message, or queue it if connection is not open
-  private sendMessageRaw(message: Object) {
+  private sendMessageRaw(message: any) {
     switch (this.status) {
       case this.wsImpl.OPEN:
+        if(message.type === MessageTypes.GQL_STOP) {
+          this.eventEmitter.emit('error', new Error(`Client is closed. Preventing message to be sent: ${message}`));
+          break;
+        }
         let serializedMessage: string = JSON.stringify(message);
         try {
           JSON.parse(serializedMessage);

--- a/src/client.ts
+++ b/src/client.ts
@@ -465,7 +465,7 @@ export class SubscriptionClient {
     switch (this.status) {
       case this.wsImpl.OPEN:
         if(message.type === MessageTypes.GQL_STOP) {
-          this.eventEmitter.emit('error', new Error(`Client is closed. Preventing message to be sent: ${message}`));
+          this.eventEmitter.emit('error', new Error(`Client is closing. Preventing message to be sent: ${message.type}`));
           break;
         }
         let serializedMessage: string = JSON.stringify(message);

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1195,6 +1195,19 @@ describe('Client', function () {
     done();
   });
 
+  it('should throw if client is being closed', (done) => {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    const originalOnMessage = subscriptionsClient.client.onmessage;
+    const dataToSend = {
+      data: JSON.stringify({ type: 'stop' }),
+    };
+
+    expect(() => {
+      originalOnMessage.call(subscriptionsClient, dataToSend)();
+    }).to.throw('Client is closing. Preventing message to be sent: stop');
+    done();
+  });
+
   it('should delete operation when receive a GQL_COMPLETE', (done) => {
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
     subscriptionsClient.operations['1'] = {


### PR DESCRIPTION
When the client is being closed, the stop message is still being sent, which causes the client to break.

![image](https://user-images.githubusercontent.com/13049940/82236245-bb1b6680-992b-11ea-97a6-937cd12c9d3a.png)
