### PR TITLE
Bump graphql deps and fix broken tests/CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "10"
-  - "8"
-  - "6"
+  - "12"
 
 install:
   - rm -rf node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v0.9.17
+
+- Bump `graphql` peer/dev deps.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#778](https://github.com/apollographql/subscriptions-transport-ws/pull/778)
+
 ### v0.9.16
 - Add ability to set custom WebSocket protocols for client. <br/>
   [@pkosiec](https://github.com/pkosiec) in [#477](https://github.com/apollographql/subscriptions-transport-ws/pull/477)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepublishOnly": "npm run clean && npm run compile && npm run browser-compile"
   },
   "peerDependencies": {
-    "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.1 || ^14.0.2"
+    "graphql": ">=0.10.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",
@@ -42,7 +42,7 @@
     "@types/sinon": "^5.0.1",
     "@types/ws": "^5.1.2",
     "chai": "^4.0.2",
-    "graphql": "^14.0.2",
+    "graphql": "^15.3.0",
     "graphql-subscriptions": "^1.0.0",
     "istanbul": "^1.0.0-alpha.2",
     "lodash": "^4.17.1",
@@ -52,7 +52,7 @@
     "rimraf": "^2.6.1",
     "sinon": "^6.1.4",
     "tslint": "^5.10.0",
-    "typescript": "^2.9.1",
+    "typescript": "^3.9.6",
     "webpack": "^3.1.0"
   },
   "typings": "dist/index.d.ts",

--- a/src/utils/empty-iterable.ts
+++ b/src/utils/empty-iterable.ts
@@ -1,6 +1,8 @@
 import { $$asyncIterator } from 'iterall';
 
-export const createEmptyIterable = (): AsyncIterator<any> => {
+type EmptyIterable = AsyncIterator<any> & { [$$asyncIterator]: any };
+
+export const createEmptyIterable = (): EmptyIterable => {
   return {
     next() {
       return Promise.resolve({ value: undefined, done: true });

--- a/tslint.json
+++ b/tslint.json
@@ -56,7 +56,6 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "no-var-requires": false,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
Quick project tweaks:

- Bump `graphql` and `typescript` peer/dev deps
- Remove deprecated `tslint` rules
- Fix broken `src/utils/empty-iterable.ts` types
- Only run CI with Node 12