### PR TITLE
Set this.client to null before calling client.close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Set client to null before calling onClose.  <br/>
+  [@ibash](https://github.com/ibash) in [#820](https://github.com/apollographql/subscriptions-transport-ws/pull/829)
+
 ## v0.9.18 (2020-08-17)
 
 ### Bug Fixes

--- a/src/client.ts
+++ b/src/client.ts
@@ -170,12 +170,13 @@ export class SubscriptionClient {
         this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_TERMINATE, null);
       }
 
-      this.client.close();
-      this.client.onopen = null;
-      this.client.onclose = null;
-      this.client.onerror = null;
-      this.client.onmessage = null;
+      const client = this.client;
       this.client = null;
+      client.close();
+      client.onopen = null;
+      client.onclose = null;
+      client.onerror = null;
+      client.onmessage = null;
       this.eventEmitter.emit('disconnected');
 
       if (!isForced) {


### PR DESCRIPTION
client.close can sometimes lead to a synchronous call to close. This
leads to the error:
[TypeError: Cannot set property 'onopen' of null]

This change sets client to null before calling onClose, so that the
second synchronous call does not try to cleanup the client.

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

