### PR TITLE
docs: Add explanation for argument of close

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ ReactDOM.render(
 - `thisContext: any`: `this` context to use when calling the callback function.
 - => Returns an `off` method to cancel the event subscription.
 
-### `close() => void` - closes the WebSocket connection manually, and ignores `reconnect` logic if it was set to `true`.
+### `close(isForced = true) => void` - closes the WebSocket connection manually, and ignores `reconnect` logic if `isForced` was set to `true`.
 
 ### `use(middlewares: MiddlewareInterface[]) => SubscriptionClient` - adds middleware to modify `OperationOptions` per each request
 - `middlewares: MiddlewareInterface[]` - Array contains list of middlewares (implemented `applyMiddleware` method) implementation, the `SubscriptionClient` will use the middlewares to modify `OperationOptions` for every operation


### PR DESCRIPTION
Hi, thank you for great work.

I've found the following issue. Some people (including me) want to reconnect manually, but there is no public method like `reconnect`. Instead, running `client.close(false)` reconnects manually, so I've added explanation for it.

https://github.com/apollographql/subscriptions-transport-ws/issues/226