### PR TITLE
catch errors throw by onDisconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Catch onDisconnect Promise rejections. <br/>
+  [@asmeikal](https://github.com/asmeikal) in [#846](https://github.com/apollographql/subscriptions-transport-ws/pull/846)
+
 ## v0.9.18 (2020-08-17)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "posttest": "npm run lint",
     "lint": "tslint --format stylish --project ./tsconfig.json",
     "watch": "tsc -w",
-    "testonly": "mocha --exit --reporter spec --full-trace ./dist/test/**/*.js",
-    "coverage": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- --exit --full-trace ./dist/test/tests.js",
+    "testonly": "mocha --throw-deprecation --exit --reporter spec --full-trace ./dist/test/**/*.js",
+    "coverage": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- --throw-deprecation --exit --full-trace ./dist/test/tests.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info",
     "browser-compile": "webpack --config \"./unpkg-webpack.config.js\"",
     "prepublishOnly": "npm run clean && npm run compile && npm run browser-compile"

--- a/src/server.ts
+++ b/src/server.ts
@@ -174,7 +174,9 @@ export class SubscriptionServer {
         this.onClose(connectionContext);
 
         if (this.onDisconnect) {
-          this.onDisconnect(socket, connectionContext);
+          Promise.resolve(this.onDisconnect(socket, connectionContext)).catch((err) => {
+            console.error('Error in onDisconnect:', err);
+          });
         }
       };
 


### PR DESCRIPTION
This PR adds a test that shows the UnhandledPromiseRejection (#222) thansk to mocha's `--throw-deprecation` flag, and removes the unhandled rejection.

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

