### PR TITLE
Allow dynamic URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.9.19 (TDB)
+- Allow for dynamic url [#847](https://github.com/apollographql/subscriptions-transport-ws/pull/847)
+
 ## v0.9.18 (2020-08-17)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ ReactDOM.render(
 
 ## SubscriptionClient
 ### `Constructor(url, options, webSocketImpl)`
-- `url: string` : url that the client will connect to, starts with `ws://` or `wss://`
+- `url: string | (() => string)` : url that the client will connect to, starts with `ws://` or `wss://` - can alternatively be a function that returns the connection url, which will be invoked every time the client tries to connect
 - `options?: Object` : optional, object to modify default client behavior
   * `timeout?: number` : how long the client should wait in ms for a keep-alive message from the server (default 30000 ms), this parameter is ignored if the server does not send keep-alive messages. This will also be used to calculate the max connection time per connect/reconnect
   * `minTimeout?: number`: the minimum amount of time the client should wait for a connection to be made (default 1000 ms)

--- a/src/client.ts
+++ b/src/client.ts
@@ -73,7 +73,7 @@ export interface ClientOptions {
 export class SubscriptionClient {
   public client: any;
   public operations: Operations;
-  private url: string;
+  private url: string | (() => string);
   private nextOperationId: number;
   private connectionParams: Function;
   private minWsTimeout: number;
@@ -100,7 +100,7 @@ export class SubscriptionClient {
   private wsOptionArguments: any[];
 
   constructor(
-    url: string,
+    url: string | (() => string),
     options?: ClientOptions,
     webSocketImpl?: any,
     webSocketProtocols?: string | string[],
@@ -554,7 +554,8 @@ export class SubscriptionClient {
   }
 
   private connect() {
-    this.client = new this.wsImpl(this.url, this.wsProtocols, ...this.wsOptionArguments);
+    const url = typeof this.url === "string" ? this.url : this.url();
+    this.client = new this.wsImpl(url, this.wsProtocols, ...this.wsOptionArguments);
 
     this.checkMaxConnectTimeout();
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -554,7 +554,7 @@ export class SubscriptionClient {
   }
 
   private connect() {
-    const url = typeof this.url === "string" ? this.url : this.url();
+    const url = typeof this.url === 'string' ? this.url : this.url();
     this.client = new this.wsImpl(url, this.wsProtocols, ...this.wsOptionArguments);
 
     this.checkMaxConnectTimeout();


### PR DESCRIPTION
This PR allows setting the url to be a function that returns a string rather than a static string.

Why?
Our organization authenticates websocket connection at the edge by parsing a jwt passed as a query parameter. When that token expires it should be reflected in the connection url.
With this change, whenever the websocket client reconnects, it will execute the function provided by the user rather than being stuck with the static string.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

