### PR TITLE
Move `@types/ws` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "eventemitter3": "^3.1.0",
     "iterall": "^1.2.1",
     "symbol-observable": "^1.0.4",
-    "ws": "^5.2.0"
+    "ws": "^5.2.0",
+    "@types/ws": "^5.1.2"
   },
   "scripts": {
     "clean": "rimraf browser dist coverage",
@@ -40,7 +41,6 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.8",
     "@types/sinon": "^5.0.1",
-    "@types/ws": "^5.1.2",
     "chai": "^4.0.2",
     "graphql": "^15.3.0",
     "graphql-subscriptions": "^1.0.0",


### PR DESCRIPTION
from devDependencies

exported type should be a dependency, otherwise the type will be unknown for library user.

fix #772

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

