### PR TITLE
Support for `graphql@16` and bump minimal supported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## v0.11.0 (2021-11-02)
 
-- Support for `graphql@16` and bump minimal supported version to be `graphql@15.7.2`. As part of this change signatures for `ExecuteFunction` and `SubscribeFunction` were changed.
+- Support for `graphql@16` and bump minimal supported version to be `graphql@15.7.2`. As part of this change signatures for `ExecuteFunction` and `SubscribeFunction` were changed.  <br/>
+  [@IvanGoncharov](https://github.com/IvanGoncharov) in [#902](https://github.com/apollographql/subscriptions-transport-ws/pull/902)
+
 
 ## v0.10.0 (2021-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.11.0 (2021-11-02)
+
+- Support for `graphql@16` and bump minimal supported version to be `graphql@15.7.2`. As part of this change signatures for `ExecuteFunction` and `SubscribeFunction` were changed.
+
 ## v0.10.0 (2021-06-08)
 
 - Same contents as v0.9.19 (published before v0.9.19 before realizing it would be helpful if the new version was picked up by packages looking for `^0.9`).

--- a/package.json
+++ b/package.json
@@ -30,11 +30,10 @@
     "prepublishOnly": "npm run clean && npm run compile && npm run browser-compile"
   },
   "peerDependencies": {
-    "graphql": ">=0.10.0"
+    "graphql": "^15.7.2 || ^16.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",
-    "@types/graphql": "^14.0.0",
     "@types/is-promise": "^2.1.0",
     "@types/lodash": "^4.14.109",
     "@types/mocha": "^5.2.5",
@@ -42,7 +41,7 @@
     "@types/sinon": "^5.0.1",
     "@types/ws": "^5.1.2",
     "chai": "^4.0.2",
-    "graphql": "^15.3.0",
+    "graphql": "16.0.0",
     "graphql-subscriptions": "^1.0.0",
     "istanbul": "^1.0.0-alpha.2",
     "lodash": "^4.17.1",
@@ -52,7 +51,7 @@
     "rimraf": "^2.6.1",
     "sinon": "^6.1.4",
     "tslint": "^5.10.0",
-    "typescript": "^3.9.6",
+    "typescript": "^4.1.0",
     "webpack": "^3.1.0"
   },
   "typings": "dist/index.d.ts",

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -792,7 +792,7 @@ describe('Client', function () {
           try {
             sub.unsubscribe();
             expect(Object.keys(client.operations).length).to.equals(0);
-            resolve();
+            resolve(undefined);
           } catch (e) {
             reject(e);
           }
@@ -2643,7 +2643,7 @@ describe('Client<->Server Flow', () => {
               assert(sRes.errors === undefined, 'unexpected error from 1st subscription');
               assert(sRes.data, 'unexpected null from 1st subscription result');
               expect(Object.keys(client['operations']).length).to.eq(1);
-              expect(sRes.data.user.id).to.eq('3');
+              expect(sRes.data.user).to.include({ id: '3' });
               firstSubscriptionSpy();
 
               firstSub.unsubscribe();
@@ -2660,7 +2660,7 @@ describe('Client<->Server Flow', () => {
                   next: (s2Res) => {
                     assert(s2Res.errors === undefined, 'unexpected error from 2nd subscription');
                     assert(s2Res.data !== null, 'unexpected null from 2nd subscription result');
-                    expect(s2Res.data.user.id).to.eq('1');
+                    expect(s2Res.data.user).to.include({ id: '1' });
                     expect(Object.keys(client['operations']).length).to.eq(1);
                     expect(firstSubscriptionSpy.callCount).to.eq(1);
 


### PR DESCRIPTION
Support for `graphql@16` and bump minimal supported version to be `graphql@15.7.2`.
As part of this change signatures for `ExecuteFunction` and `SubscribeFunction` were changed.
