### PR TITLE
Emit a Keep alive / Time out error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.11.1 (2022-01-17)
+
+- Emit a `Timed out` error when the web socket has not received a keep alive message in time.
+
 ## v0.11.0 (2021-11-02)
 
 - Support for `graphql@16` and bump minimal supported version to be `graphql@15.7.2`. As part of this change signatures for `ExecuteFunction` and `SubscribeFunction` were changed.  <br/>

--- a/src/client.ts
+++ b/src/client.ts
@@ -538,7 +538,7 @@ export class SubscriptionClient {
 
     if (!this.reconnecting) {
       this.eventEmitter.emit('error', new Error('Timed out'));
-      this.close(false, true);
+      this.close(!this.reconnect, true);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -537,6 +537,7 @@ export class SubscriptionClient {
     }
 
     if (!this.reconnecting) {
+      this.eventEmitter.emit('error', new Error('Timed out'));
       this.close(false, true);
     }
   }

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1208,6 +1208,14 @@ describe('Client', function () {
     }, 1300);
   });
 
+  it('should emit an error when no keep alive messages are received', (done) => {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${KEEP_ALIVE_TEST_PORT}/`, { timeout: 100, reconnect: false });
+    subscriptionsClient.onError((err: Error) => {
+      expect(err.message).to.be.equal('Timed out');
+      done();
+    });
+  });
+
   it('should take care of invalid message received', (done) => {
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
     const originalOnMessage = subscriptionsClient.client.onmessage;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Our team is currently using this library, and we would love it if we were able to log time-out issues. 
This PR makes it possible! ❤️

**Note**: When the WS connection times out, it has to be force closed when reconnect is not enabled, otherwise, `checkConnectionIntervalId` will keep on spewing out timed-out errors... _forever_. I don't know if this has any bad side effects? The tests still seem to pass just fine! ^^

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

